### PR TITLE
Add Peshawar High Court crawler pipeline (#5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,7 @@ A multi-agent legal intelligence platform for Pakistani law. LangGraph Deep Agen
 - Never discard metadata — extract everything, filter later
 - Type hints on all function signatures
 - Pydantic models for all data structures crossing module boundaries
+- **crawl4ai docs-first**: Before implementing any crawling/extraction logic, ALWAYS check crawl4ai docs (https://docs.crawl4ai.com/) for built-in solutions. Use native strategies (`DefaultTableExtraction`, `JsonCssExtractionStrategy`, session management, `js_only`) instead of reinventing with custom JS injection or manual HTML parsing. Key docs: `/core/table_extraction/`, `/extraction/no-llm-strategies/`, `/advanced/session-management/`, `/core/page-interaction/`
 
 ## Directory Structure
 
@@ -178,7 +179,8 @@ A multi-agent legal intelligence platform for Pakistani law. LangGraph Deep Agen
 ├── plans.md
 ├── src/
 │   ├── pipelines/           # crawl4ai extractors (one per site)
-│   │   └── commonlii/      # ✓ IMPLEMENTED — 2,906 SC cases
+│   │   ├── commonlii/      # ✓ IMPLEMENTED — 2,906 SC cases
+│   │   └── peshawar_hc/    # ✓ IMPLEMENTED — 5,590 reported judgments
 │   ├── extractors/          # Structured field extractors
 │   │   ├── common/          # Shared utilities (llm_client, json_utils)
 │   │   └── criminal/        # ✓ IMPLEMENTED — 4-pass extraction

--- a/src/extractors/common/court_classifier.py
+++ b/src/extractors/common/court_classifier.py
@@ -6,9 +6,12 @@ Reused by all court-specific pipelines and Tier A extractors.
 
 from __future__ import annotations
 
+import logging
 import re
 from enum import Enum
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 
 class CourtCode(str, Enum):
@@ -73,6 +76,8 @@ _NAME_TO_CODE: dict[str, CourtCode] = {
 
 def extract_court_name(text: str) -> Optional[str]:
     """Extract court name from judgment header (first 2000 chars)."""
+    if not text:
+        return None
     header = text[:2000]
     for court in _COURT_NAMES:
         m = re.search(court, header, re.IGNORECASE)
@@ -95,7 +100,10 @@ def classify_court_code(court_name: Optional[str] = None, text: str = "") -> Cou
         court_name: Extracted court name (preferred).
         text: Full text to search if court_name is None.
     """
-    source = (court_name or text).lower()
+    source = (court_name or text or "").lower()
+    if not source.strip():
+        logger.warning("classify_court_code called with no court_name and empty text")
+        return CourtCode.UNKNOWN
     for key, code in _NAME_TO_CODE.items():
         if key in source:
             return code
@@ -104,6 +112,7 @@ def classify_court_code(court_name: Optional[str] = None, text: str = "") -> Cou
         return CourtCode.SESSIONS
     if "district" in source:
         return CourtCode.DISTRICT
+    logger.info("Court code UNKNOWN for: %.80s", source.strip())
     return CourtCode.UNKNOWN
 
 

--- a/src/extractors/common/dedup.py
+++ b/src/extractors/common/dedup.py
@@ -21,7 +21,12 @@ def text_hash(text: str) -> str:
 
     Normalizes whitespace and lowercases before hashing so minor
     formatting differences between sources don't create false negatives.
+
+    Raises ValueError for empty/whitespace-only text to prevent
+    false duplicate collisions from failed extractions.
     """
+    if not text or not text.strip():
+        raise ValueError("Cannot hash empty text — likely a failed extraction")
     normalized = re.sub(r"\s+", " ", text.strip().lower())
     return hashlib.sha256(normalized.encode("utf-8")).hexdigest()
 

--- a/src/extractors/common/judge_extractor.py
+++ b/src/extractors/common/judge_extractor.py
@@ -6,7 +6,10 @@ Handles "PRESENT: Mr. Justice X" blocks and "Hon'ble" patterns.
 
 from __future__ import annotations
 
+import logging
 import re
+
+logger = logging.getLogger(__name__)
 
 
 _STOP_WORDS = {
@@ -27,43 +30,58 @@ def extract_judge_names(text: str) -> list[str]:
 
     Returns sorted, deduplicated list of cleaned names.
     """
+    if not text:
+        return []
     judges: set[str] = set()
     header = re.sub(r"\s+", " ", text[:3000])
 
-    # Pattern 1: "Mr./Mrs./Ms. Justice <Name>"
+    # Name token: matches Title Case ("Iftikhar") and ALL CAPS ("IFTIKHAR")
+    _NAME_TOKEN = r"[A-Z][a-zA-Z]+"
+    _NAME_SEQ = rf"{_NAME_TOKEN}(?:\s+{_NAME_TOKEN}){{1,5}}"
+
+    # Pattern 1: "Mr./MR./Mrs./Ms. Justice <Name>"
     for m in re.finditer(
-        r"(?:Mr\.|Mrs\.|Ms\.)?\s*Justice\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,5})",
+        rf"(?:MR\.|Mr\.|MRS\.|Mrs\.|MS\.|Ms\.)?\s*(?:JUSTICE|Justice)\s+({_NAME_SEQ})",
         header,
     ):
-        name = _clean_name(m.group(1).strip())
+        name = _clean_name(_title_case(m.group(1).strip()))
         if name:
             judges.add(name)
 
-    # Pattern 2: "PRESENT: ..." block
+    # Pattern 2: "PRESENT: ..." block (end at double newline, section start, or end of text)
     present_block = re.search(
-        r"PRESENT[:\s]+(.+?)(?:\n\n|\n[A-Z])",
+        r"PRESENT[:\s]+(.+?)(?:\n\n|\n[A-Z]|$)",
         text[:3000],
         re.DOTALL | re.IGNORECASE,
     )
     if present_block:
         normalized = re.sub(r"\s+", " ", present_block.group(1))
         for m in re.finditer(
-            r"Justice\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,5})", normalized
+            rf"(?:JUSTICE|Justice)\s+({_NAME_SEQ})", normalized
         ):
-            name = _clean_name(m.group(1).strip())
+            name = _clean_name(_title_case(m.group(1).strip()))
             if name:
                 judges.add(name)
 
     # Pattern 3: "Hon'ble Justice <Name>"
     for m in re.finditer(
-        r"Hon['\u2019]?ble\s+(?:Mr\.\s+)?Justice\s+([A-Z][a-z]+(?:\s+[A-Z][a-z]+){1,5})",
+        rf"Hon['\u2019]?ble\s+(?:(?:Mr|MR)\.\s+)?(?:JUSTICE|Justice)\s+({_NAME_SEQ})",
         header,
     ):
-        name = _clean_name(m.group(1).strip())
+        name = _clean_name(_title_case(m.group(1).strip()))
         if name:
             judges.add(name)
 
+    if not judges and len(text) > 500:
+        logger.info("No judge names found in %d-char text: %.80s", len(text), header[:80])
     return sorted(judges)
+
+
+def _title_case(name: str) -> str:
+    """Normalize ALL CAPS names to Title Case for consistent dedup."""
+    if name.isupper():
+        return name.title()
+    return name
 
 
 def _clean_name(name: str) -> str | None:

--- a/src/extractors/common/pdf_extract.py
+++ b/src/extractors/common/pdf_extract.py
@@ -7,10 +7,10 @@ Reused by all court pipeline crawlers.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 import tempfile
-import time
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
@@ -123,7 +123,7 @@ async def download_pdf(
                     "Download attempt %d/%d failed for %s: %s (retrying in %ds)",
                     attempt, max_retries, url, e, wait,
                 )
-                time.sleep(wait)
+                await asyncio.sleep(wait)
 
     logger.error("Download failed after %d attempts: %s: %s", max_retries, url, last_error)
     return None

--- a/src/extractors/common/quality_validator.py
+++ b/src/extractors/common/quality_validator.py
@@ -49,7 +49,7 @@ MIN_TIER_A_COVERAGE = 15.0  # percent
 
 def validate_extraction(
     text: str,
-    payload: dict[str, Any],
+    payload: dict[str, Any] | None,
     case_number: str = "",
 ) -> QualityReport:
     """Validate an extraction result before Qdrant ingestion.
@@ -63,6 +63,10 @@ def validate_extraction(
         QualityReport with pass/fail status and error/warning lists.
     """
     report = QualityReport(case_number=case_number)
+
+    if payload is None:
+        report.fail("Payload is None — extraction likely failed completely")
+        return report
 
     # 1. Text length check
     if not text or len(text.strip()) < MIN_TEXT_LENGTH:
@@ -88,7 +92,7 @@ def validate_extraction(
     total = len(payload)
     filled = sum(
         1 for v in payload.values()
-        if v is not None and v != [] and v != "" and v != 0
+        if v is not None and v != [] and v != ""
     )
     report.field_coverage = round(filled / max(total, 1) * 100, 1)
 

--- a/src/extractors/common/rate_limiter.py
+++ b/src/extractors/common/rate_limiter.py
@@ -32,6 +32,8 @@ class RateLimiter:
         requests_per_second: float = 2.0,
         burst: int | None = None,
     ) -> None:
+        if requests_per_second <= 0:
+            raise ValueError(f"requests_per_second must be positive, got {requests_per_second}")
         self.rate = requests_per_second
         self.burst = burst or max(1, int(requests_per_second))
         self._tokens = float(self.burst)

--- a/src/extractors/common/section_splitter.py
+++ b/src/extractors/common/section_splitter.py
@@ -87,6 +87,7 @@ def split_judgment(text: str) -> dict[str, str]:
     result: dict[str, str] = {"full_text": text}
 
     if not text or len(text.strip()) < 200:
+        result["header"] = text.strip() if text else ""
         return result
 
     # Header is always the first ~15% of the judgment (court info, parties, etc.)

--- a/src/pipelines/peshawar_hc/constants.py
+++ b/src/pipelines/peshawar_hc/constants.py
@@ -1,0 +1,25 @@
+"""Shared constants for the Peshawar High Court crawler pipeline."""
+
+BASE_URL = "https://www.peshawarhighcourt.gov.pk"
+JUDGMENTS_URL = f"{BASE_URL}/PHCCMS/reportedJudgments.php"
+SEARCH_URL = f"{JUDGMENTS_URL}?action=search"
+PDF_BASE_URL = f"{BASE_URL}/PHCCMS//judgments/"
+
+# Available filter values discovered via recon
+YEARS = list(range(2010, 2027))
+
+# Category name → form <option> value mapping
+# The form uses numeric IDs, not text labels
+CATEGORY_VALUES = {
+    "Criminal": "1",
+    "Civil": "2",
+    "Revenu": "3",  # sic — typo on the website
+    "Constitutional": "4",
+    "Service": "5",
+    "Corporate": "6",
+}
+
+CATEGORIES = list(CATEGORY_VALUES.keys())
+
+# Court code used in Qdrant point IDs
+COURT_CODE = "PHC"

--- a/src/pipelines/peshawar_hc/errors.py
+++ b/src/pipelines/peshawar_hc/errors.py
@@ -1,0 +1,9 @@
+"""Custom exceptions for the Peshawar HC crawler pipeline."""
+
+
+class CrawlError(Exception):
+    """Raised when a crawl operation fails irrecoverably."""
+
+
+class ExtractionError(Exception):
+    """Raised when data extraction from HTML/PDF fails."""

--- a/src/pipelines/peshawar_hc/listing.py
+++ b/src/pipelines/peshawar_hc/listing.py
@@ -1,0 +1,363 @@
+"""Crawl Peshawar HC reported judgments and extract case metadata from the table.
+
+Single responsibility: form submission + DataTable HTML → list of JudgmentRecord.
+
+The PHC website uses a server-rendered HTML form (POST) that returns ALL matching
+rows in a client-side jQuery DataTable (no server-side pagination).
+
+Uses crawl4ai native features:
+- session_id + js_only for multi-step form interaction
+- JsonCssExtractionStrategy for row-level extraction with PDF href attributes
+
+Table columns (0-indexed):
+  0: S.No
+  1: Case (case number + title)
+  2: Remarks (headnote / summary)
+  3: Other Citation (e.g. "2025 PLJ Pesh. 100")
+  4: PHC Neutral Citation
+  5: Decision Date (dd-mm-yyyy)
+  6: S.C.Status
+  7: Category (Criminal, Civil, etc.)
+  8: Judgment (PDF link)
+  9: SC Judgment (PDF link, if any)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import date
+
+from pydantic import BaseModel
+
+from .constants import JUDGMENTS_URL
+from .errors import CrawlError
+
+logger = logging.getLogger(__name__)
+
+
+class JudgmentRecord(BaseModel):
+    """A single judgment row extracted from the PHC DataTable."""
+
+    serial: int
+    case_number: str
+    case_title: str
+    remarks: str
+    other_citation: str
+    neutral_citation: str
+    decision_date: str
+    decision_date_parsed: date | None = None
+    sc_status: str
+    category: str
+    pdf_url: str
+    sc_pdf_url: str
+    source_url: str
+
+
+def _parse_case_field(raw: str) -> tuple[str, str]:
+    """Split 'W.P No. 1395-M of 2019 Sayyed Mukammal Shah Vs Mst. Nasira' into number + title."""
+    raw = raw.strip()
+    match = re.match(
+        r"^(.+?(?:of|OF)\s+\d{4})\s+(.+)$",
+        raw,
+    )
+    if match:
+        return match.group(1).strip(), match.group(2).strip()
+    return raw, ""
+
+
+def _parse_date(raw: str) -> date | None:
+    """Parse dd-mm-yyyy date string."""
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        parts = raw.split("-")
+        if len(parts) == 3:
+            return date(int(parts[2]), int(parts[1]), int(parts[0]))
+    except (ValueError, IndexError):
+        pass
+    logger.debug("Could not parse date: %s", raw)
+    return None
+
+
+# Column names matching the PHC table headers
+TABLE_HEADERS = [
+    "S.No", "Case", "Remarks", "Other Citation",
+    "PHC Neutral Citation", "Decision Date", "S.C.Status",
+    "Category", "Judgment", "SC Judgment",
+]
+
+
+def parse_table_data(table_data: dict, source_url: str) -> list[JudgmentRecord]:
+    """Parse a crawl4ai table extraction result into JudgmentRecord models.
+
+    Args:
+        table_data: Dict with 'headers' and 'rows' from DefaultTableExtraction.
+        source_url: Source URL for provenance tracking.
+    """
+    headers = table_data.get("headers", [])
+    rows = table_data.get("rows", [])
+
+    if not rows:
+        return []
+
+    records = []
+    for row in rows:
+        # Map by header position — handle variable header names
+        row_dict = dict(zip(headers, row)) if headers else {}
+        if not row_dict:
+            # Fallback: use positional access
+            if len(row) < 9:
+                continue
+            row_dict = dict(zip(TABLE_HEADERS, row))
+
+        case_raw = row_dict.get("Case", "")
+        case_number, case_title = _parse_case_field(case_raw)
+        decision_date_raw = row_dict.get("Decision Date", "").strip()
+
+        # The Judgment and SC Judgment columns contain HTML with <a> tags.
+        # crawl4ai table extraction gives us the cell text, but we need the href.
+        # We extract PDF URLs separately via JsonCssExtractionStrategy.
+        record = JudgmentRecord(
+            serial=int(row_dict.get("S.No", 0) or 0),
+            case_number=case_number,
+            case_title=case_title,
+            remarks=row_dict.get("Remarks", "").strip(),
+            other_citation=row_dict.get("Other Citation", "").strip(),
+            neutral_citation=row_dict.get("PHC Neutral Citation", "").strip(),
+            decision_date=decision_date_raw,
+            decision_date_parsed=_parse_date(decision_date_raw),
+            sc_status=row_dict.get("S.C.Status", "").strip(),
+            category=row_dict.get("Category", "").strip(),
+            pdf_url="",  # Populated by CSS extraction step
+            sc_pdf_url="",  # Populated by CSS extraction step
+            source_url=source_url,
+        )
+        records.append(record)
+
+    return records
+
+
+def parse_css_rows(raw_rows: list[dict], source_url: str) -> list[JudgmentRecord]:
+    """Parse rows from JsonCssExtractionStrategy into JudgmentRecord models."""
+    records = []
+    for row in raw_rows:
+        case_number, case_title = _parse_case_field(row.get("case", ""))
+        decision_date_raw = row.get("decision_date", "").strip()
+
+        record = JudgmentRecord(
+            serial=int(row.get("serial", 0) or 0),
+            case_number=case_number,
+            case_title=case_title,
+            remarks=row.get("remarks", "").strip(),
+            other_citation=row.get("other_citation", "").strip(),
+            neutral_citation=row.get("neutral_citation", "").strip(),
+            decision_date=decision_date_raw,
+            decision_date_parsed=_parse_date(decision_date_raw),
+            sc_status=row.get("sc_status", "").strip(),
+            category=row.get("category", "").strip(),
+            pdf_url=row.get("pdf_url", "").strip(),
+            sc_pdf_url=row.get("sc_pdf_url", "").strip(),
+            source_url=source_url,
+        )
+        records.append(record)
+
+    return records
+
+
+# JsonCssExtractionStrategy schema for the PHC DataTable rows.
+# This captures PDF links (as href attributes) which DefaultTableExtraction misses.
+CSS_EXTRACTION_SCHEMA = {
+    "name": "PHC Judgments",
+    "baseSelector": "#employee_list tbody tr",
+    "fields": [
+        {"name": "serial", "selector": "td:nth-child(1)", "type": "text"},
+        {"name": "case", "selector": "td:nth-child(2)", "type": "text"},
+        {"name": "remarks", "selector": "td:nth-child(3)", "type": "text"},
+        {"name": "other_citation", "selector": "td:nth-child(4)", "type": "text"},
+        {"name": "neutral_citation", "selector": "td:nth-child(5)", "type": "text"},
+        {"name": "decision_date", "selector": "td:nth-child(6)", "type": "text"},
+        {"name": "sc_status", "selector": "td:nth-child(7)", "type": "text"},
+        {"name": "category", "selector": "td:nth-child(8)", "type": "text"},
+        {
+            "name": "pdf_url",
+            "selector": "td:nth-child(9) a",
+            "type": "attribute",
+            "attribute": "href",
+        },
+        {
+            "name": "sc_pdf_url",
+            "selector": "td:nth-child(10) a",
+            "type": "attribute",
+            "attribute": "href",
+        },
+    ],
+}
+
+
+def _build_submit_js(
+    year: int | None = None,
+    judge: str | None = None,
+) -> str:
+    """Build JavaScript to fill and submit the search form.
+
+    The PHC form uses numeric option values, not text labels:
+    - Year: "2024" (text matches value)
+    - Judge: numeric IDs like "26", "25", etc.
+
+    NOTE: Category filter is NOT set via form because the PHC server returns
+    HTTP 500 for any category value other than 0 (all). Category filtering
+    is done client-side in Python after extraction.
+    """
+    parts = []
+    if year is not None:
+        parts.append(f"document.querySelector('#year').value = '{year}';")
+    if judge is not None:
+        parts.append(f"document.querySelector('#judge').value = '{judge}';")
+    parts.append("document.querySelector('input[type=\"submit\"]').click();")
+    return "\n".join(parts)
+
+
+async def crawl_judgments(
+    year: int | None = None,
+    category: str | None = None,
+    judge: str | None = None,
+) -> list[JudgmentRecord]:
+    """Crawl PHC reported judgments by submitting the search form.
+
+    Two-step crawl4ai session approach:
+    1. Load form page, fill year/judge fields, submit (triggers navigation).
+       crawl4ai's robust_execute_user_script handles the context-destroyed
+       error from navigation automatically.
+    2. On the results page (same session, js_only=True), expand DataTable
+       to show all rows, then extract with JsonCssExtractionStrategy.
+
+    Category filtering is done client-side because the PHC server returns
+    HTTP 500 for any category value other than 0 (all).
+
+    Args:
+        year: Filter by year (2010-2026). None for all years.
+        category: Filter by category (client-side). None for all.
+        judge: Filter by judge name. None for all.
+
+    Returns:
+        List of JudgmentRecord extracted from the results table.
+
+    Raises:
+        CrawlError: If the page cannot be loaded or extraction fails.
+    """
+    from crawl4ai import (
+        AsyncWebCrawler,
+        BrowserConfig,
+        CacheMode,
+        CrawlerRunConfig,
+        JsonCssExtractionStrategy,
+    )
+
+    browser_config = BrowserConfig(
+        headless=True,
+        extra_args=["--ignore-certificate-errors"],
+    )
+
+    # Script 1: Fill form and submit (triggers navigation to results page).
+    # crawl4ai's robust_execute_user_script catches "context destroyed" from
+    # the navigation and waits for the new page to load before continuing.
+    submit_js = _build_submit_js(year, judge)
+
+    # Script 2: Runs on the results page after navigation completes.
+    # Polls for DataTable initialization (jQuery loads async), then shows all rows.
+    expand_datatable_js = """
+    (async () => {
+        // Poll until jQuery DataTable is initialized (up to 15s)
+        for (let i = 0; i < 30; i++) {
+            if (typeof $ !== 'undefined' && $.fn.DataTable
+                && $.fn.DataTable.isDataTable('#employee_list')) {
+                const dt = $('#employee_list').DataTable();
+                dt.page.len(-1).draw();
+                await new Promise(r => setTimeout(r, 500));
+                return;
+            }
+            await new Promise(r => setTimeout(r, 500));
+        }
+    })();
+    """
+
+    extraction_strategy = JsonCssExtractionStrategy(
+        schema=CSS_EXTRACTION_SCHEMA, verbose=False,
+    )
+
+    session_id = "phc_session"
+
+    async with AsyncWebCrawler(config=browser_config) as crawler:
+        # Step 1: Load form page, fill, and submit. The form submit triggers
+        # a full page navigation which crawl4ai handles automatically via
+        # robust_execute_user_script's "context destroyed" handling.
+        step1_config = CrawlerRunConfig(
+            session_id=session_id,
+            cache_mode=CacheMode.BYPASS,
+            wait_until="networkidle",
+            js_code=submit_js,
+            delay_before_return_html=5.0,
+            page_timeout=90000,
+        )
+        result = await crawler.arun(url=JUDGMENTS_URL, config=step1_config)
+        if not result.success:
+            raise CrawlError(f"Form submission failed: {result.error_message}")
+
+        # Step 2: On the results page (same session), expand DataTable and extract.
+        step2_config = CrawlerRunConfig(
+            session_id=session_id,
+            cache_mode=CacheMode.BYPASS,
+            js_only=True,
+            js_code=expand_datatable_js,
+            wait_for="css:#employee_list",
+            delay_before_return_html=2.0,
+            extraction_strategy=extraction_strategy,
+            page_timeout=30000,
+        )
+        result = await crawler.arun(url=JUDGMENTS_URL, config=step2_config)
+
+        if not result.success:
+            raise CrawlError(f"Data extraction failed: {result.error_message}")
+
+        # Parse extracted content
+        records = []
+        if result.extracted_content:
+            try:
+                raw_rows = json.loads(result.extracted_content)
+                records = parse_css_rows(raw_rows, JUDGMENTS_URL)
+            except json.JSONDecodeError as e:
+                raise CrawlError(f"Failed to parse extracted JSON: {e}") from e
+
+    # Client-side category filter (PHC server returns 500 for category != 0)
+    if category and records:
+        before = len(records)
+        records = [r for r in records if r.category.lower() == category.lower()]
+        logger.info(
+            "Category filter '%s': %d → %d records",
+            category, before, len(records),
+        )
+
+    if not records:
+        logger.warning(
+            "No records found for year=%s category=%s judge=%s",
+            year, category, judge,
+        )
+
+    logger.info(
+        "Crawled %d judgment records (year=%s, category=%s)",
+        len(records), year, category,
+    )
+    return records
+
+
+async def crawl_all_years() -> list[JudgmentRecord]:
+    """Crawl all reported judgments (all years, all categories)."""
+    return await crawl_judgments(year=None, category=None)
+
+
+async def crawl_by_year(year: int) -> list[JudgmentRecord]:
+    """Crawl reported judgments for a specific year."""
+    return await crawl_judgments(year=year, category=None)

--- a/src/pipelines/peshawar_hc/pipeline.py
+++ b/src/pipelines/peshawar_hc/pipeline.py
@@ -1,0 +1,254 @@
+"""Peshawar High Court crawler pipeline.
+
+Orchestrates the full flow: form search → table extraction → PDF download → text output.
+Single responsibility: coordinate the pipeline stages with crash resilience.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+
+from src.extractors.common.pdf_extract import download_and_extract
+
+from .constants import COURT_CODE
+from .listing import JudgmentRecord, crawl_judgments
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OUTPUT_DIR = Path(
+    os.environ.get("PHC_OUTPUT_DIR", "data/peshawar_hc")
+)
+
+CHECKPOINT_INTERVAL = 25
+
+
+async def crawl_full(
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    limit: int | None = None,
+    year: int | None = None,
+    category: str | None = None,
+) -> list[dict]:
+    """Crawl PHC reported judgments and extract PDF text.
+
+    Args:
+        output_dir: Directory to save results and PDFs.
+        limit: Max number of judgments to process. None for all.
+        year: Filter by year. None for all years.
+        category: Filter by category. None for all.
+
+    Returns:
+        List of result dicts with metadata + extracted text.
+
+    Raises:
+        CrawlError: If the listing page cannot be crawled.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    pdf_dir = output_dir / "pdfs"
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+
+    # Stage 1: Get judgment records from the search table
+    logger.info("Stage 1: Crawling judgment listings (year=%s, category=%s)...", year, category)
+    records = await crawl_judgments(year=year, category=category)
+    logger.info("Found %d judgment records", len(records))
+
+    if limit:
+        records = records[:limit]
+        logger.info("Limited to %d records", limit)
+
+    # Stage 2: Download PDFs and extract text
+    results = await _process_records(records, pdf_dir)
+
+    # Save results
+    _save_results(results, output_dir / "results.jsonl")
+    _save_summary(results, output_dir / "summary.json")
+    return results
+
+
+async def crawl_year(
+    year: int,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    limit: int | None = None,
+) -> list[dict]:
+    """Crawl a single year of PHC judgments."""
+    return await crawl_full(output_dir=output_dir, limit=limit, year=year)
+
+
+async def _process_records(
+    records: list[JudgmentRecord],
+    pdf_dir: Path,
+) -> list[dict]:
+    """Download PDFs and extract text for each judgment record.
+
+    Per-record error isolation so one failure doesn't kill the batch.
+    Checkpoint saves every CHECKPOINT_INTERVAL records.
+    """
+    results: list[dict] = []
+    seen_urls: set[str] = set()
+    checkpoint_path = pdf_dir.parent / "checkpoint.jsonl"
+    failed_count = 0
+
+    for idx, record in enumerate(records):
+        # Deduplicate by PDF URL
+        if record.pdf_url and record.pdf_url in seen_urls:
+            logger.debug("Skipping duplicate PDF: %s", record.pdf_url)
+            continue
+        if record.pdf_url:
+            seen_urls.add(record.pdf_url)
+
+        try:
+            result = await _process_single_record(record, pdf_dir)
+            results.append(result)
+
+            if result["text"]:
+                logger.info(
+                    "[%d/%d] OK: %s — %d chars",
+                    idx + 1, len(records),
+                    record.case_number or "?",
+                    result["text_length"],
+                )
+            else:
+                logger.warning(
+                    "[%d/%d] EMPTY: %s — no text extracted",
+                    idx + 1, len(records),
+                    record.case_number or record.pdf_url,
+                )
+
+        except Exception as e:
+            failed_count += 1
+            logger.error(
+                "[%d/%d] FAILED: %s: %s",
+                idx + 1, len(records), record.case_number, e,
+                exc_info=True,
+            )
+            results.append({
+                **record.model_dump(),
+                "text": "",
+                "text_length": 0,
+                "error": str(e),
+                "source": "peshawar_hc",
+                "court": COURT_CODE,
+            })
+
+        # Checkpoint save
+        if len(results) % CHECKPOINT_INTERVAL == 0 and results:
+            _save_results(results, checkpoint_path)
+            logger.info("Checkpoint: %d results saved", len(results))
+
+    with_text = sum(1 for r in results if r["text"])
+    logger.info(
+        "Processed %d records: %d with text, %d empty, %d failed",
+        len(results), with_text, len(results) - with_text - failed_count, failed_count,
+    )
+    return results
+
+
+async def _process_single_record(
+    record: JudgmentRecord,
+    pdf_dir: Path,
+) -> dict:
+    """Download PDF and extract text for a single judgment record."""
+    text = ""
+    if record.pdf_url:
+        text = await download_and_extract(record.pdf_url, pdf_dir)
+    else:
+        logger.warning("No PDF URL for %s", record.case_number)
+
+    return {
+        **record.model_dump(),
+        "text": text,
+        "text_length": len(text),
+        "source": "peshawar_hc",
+        "court": COURT_CODE,
+    }
+
+
+def _save_results(results: list[dict], path: Path) -> None:
+    """Save results as JSONL."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(path, "w") as f:
+            for result in results:
+                # Convert date objects to strings for JSON serialization
+                row = {}
+                for k, v in result.items():
+                    if hasattr(v, "isoformat"):
+                        row[k] = v.isoformat()
+                    else:
+                        row[k] = v
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+        logger.info("Saved %d results to %s", len(results), path)
+    except (OSError, TypeError) as e:
+        logger.error("Failed to save results to %s: %s", path, e)
+        raise
+
+
+def _save_summary(results: list[dict], path: Path) -> None:
+    """Save a summary of the crawl run."""
+    with_text = sum(1 for r in results if r.get("text"))
+    errors = sum(1 for r in results if r.get("error"))
+
+    by_category: dict[str, int] = {}
+    for r in results:
+        cat = r.get("category", "unknown")
+        by_category[cat] = by_category.get(cat, 0) + 1
+
+    summary = {
+        "total_records": len(results),
+        "with_text": with_text,
+        "empty_text": len(results) - with_text,
+        "errors": errors,
+        "by_category": by_category,
+        "records": [
+            {
+                "case_number": r.get("case_number"),
+                "category": r.get("category"),
+                "decision_date": r.get("decision_date"),
+                "text_length": r.get("text_length", 0),
+                "error": r.get("error"),
+            }
+            for r in results
+        ],
+    }
+    try:
+        with open(path, "w") as f:
+            json.dump(summary, f, indent=2, ensure_ascii=False)
+    except (OSError, TypeError) as e:
+        logger.error("Failed to save summary to %s: %s", path, e)
+
+
+async def main():
+    """CLI entry point."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Peshawar High Court Judgment Crawler")
+    parser.add_argument("--year", type=int, default=None, help="Filter by year (2010-2026)")
+    parser.add_argument("--category", type=str, default=None, help="Filter by category")
+    parser.add_argument("--limit", type=int, default=None, help="Max judgments to process")
+    parser.add_argument("--output", type=str, default=str(DEFAULT_OUTPUT_DIR))
+    args = parser.parse_args()
+
+    output_dir = Path(args.output)
+
+    results = await crawl_full(
+        output_dir=output_dir,
+        limit=args.limit,
+        year=args.year,
+        category=args.category,
+    )
+
+    with_text = sum(1 for r in results if r["text"])
+    errors = sum(1 for r in results if r.get("error"))
+    logger.info("Done: %d records, %d with text, %d errors", len(results), with_text, errors)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_peshawar_hc.py
+++ b/tests/test_peshawar_hc.py
@@ -1,0 +1,218 @@
+"""Tests for the Peshawar HC crawler pipeline.
+
+Tests parsing logic with real sample data from PHC website recon.
+Does NOT hit the live website — all tests use offline sample data.
+"""
+
+from datetime import date
+
+import pytest
+
+from src.pipelines.peshawar_hc.listing import (
+    JudgmentRecord,
+    _parse_case_field,
+    _parse_date,
+    parse_css_rows,
+    parse_table_data,
+)
+
+
+class TestParseCaseField:
+    def test_standard_case_number(self):
+        raw = "W.P No. 1395-M of 2019 Sayyed Mukammal Shah  Vs  Mst. Nasira and others"
+        number, title = _parse_case_field(raw)
+        assert number == "W.P No. 1395-M of 2019"
+        assert title == "Sayyed Mukammal Shah  Vs  Mst. Nasira and others"
+
+    def test_criminal_appeal(self):
+        raw = "Cr.A No. 650-P of 2025 Jamil Khan  Vs  The State etc"
+        number, title = _parse_case_field(raw)
+        assert number == "Cr.A No. 650-P of 2025"
+        assert "Jamil Khan" in title
+
+    def test_fao_case(self):
+        raw = "F.A.O No. 10-P of 2013 Abdul Qahar  Vs  Haji Taskeen Ahmad"
+        number, title = _parse_case_field(raw)
+        assert number == "F.A.O No. 10-P of 2013"
+        assert "Abdul Qahar" in title
+
+    def test_no_vs_separator(self):
+        raw = "W.P No. 4840-P of 2023 Hashmat Ullah omed & others"
+        number, title = _parse_case_field(raw)
+        assert number == "W.P No. 4840-P of 2023"
+
+    def test_empty_input(self):
+        number, title = _parse_case_field("")
+        assert number == ""
+        assert title == ""
+
+    def test_no_match(self):
+        raw = "Some random text without case pattern"
+        number, title = _parse_case_field(raw)
+        assert number == raw
+        assert title == ""
+
+
+class TestParseDate:
+    def test_standard_date(self):
+        assert _parse_date("23-12-2024") == date(2024, 12, 23)
+
+    def test_single_digit_day(self):
+        assert _parse_date("5-01-2023") == date(2023, 1, 5)
+
+    def test_empty(self):
+        assert _parse_date("") is None
+
+    def test_invalid(self):
+        assert _parse_date("not-a-date") is None
+
+    def test_whitespace(self):
+        assert _parse_date("  23-12-2024  ") == date(2024, 12, 23)
+
+
+class TestParseTableData:
+    """Tests for DefaultTableExtraction output parsing."""
+
+    @pytest.fixture
+    def sample_table(self):
+        return {
+            "headers": [
+                "S.No", "Case", "Remarks", "Other Citation",
+                "PHC Neutral Citation", "Decision Date", "S.C.Status",
+                "Category", "Judgment", "SC Judgment",
+            ],
+            "rows": [
+                [
+                    "1",
+                    "W.P No. 1395-M of 2019 Sayyed Mukammal Shah  Vs  Mst. Nasira and others",
+                    "Relinquishment of dower by the wife",
+                    "awaited",
+                    "",
+                    "23-12-2024",
+                    "",
+                    "Constitutional",
+                    "",  # PDF link not captured by table extraction
+                    "",
+                ],
+                [
+                    "2",
+                    "WP. No. 883-M of 2018 Akmal Khan etc  vs  Mst. Noorin etc",
+                    "Registration of dower deed",
+                    "2025 PLJ Pesh. 100",
+                    "2024 PHC 50",
+                    "13-12-2024",
+                    "Dismissed",
+                    "Civil",
+                    "",
+                    "",
+                ],
+            ],
+        }
+
+    def test_parses_records(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert len(records) == 2
+        assert all(isinstance(r, JudgmentRecord) for r in records)
+
+    def test_case_number_parsed(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert records[0].case_number == "W.P No. 1395-M of 2019"
+        assert records[0].case_title == "Sayyed Mukammal Shah  Vs  Mst. Nasira and others"
+
+    def test_date_parsed(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert records[0].decision_date_parsed == date(2024, 12, 23)
+        assert records[0].decision_date == "23-12-2024"
+
+    def test_category(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert records[0].category == "Constitutional"
+        assert records[1].category == "Civil"
+
+    def test_citation(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert records[0].other_citation == "awaited"
+        assert records[1].other_citation == "2025 PLJ Pesh. 100"
+
+    def test_neutral_citation(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert records[1].neutral_citation == "2024 PHC 50"
+
+    def test_sc_status(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert records[0].sc_status == ""
+        assert records[1].sc_status == "Dismissed"
+
+    def test_empty_rows(self):
+        table = {"headers": ["S.No", "Case"], "rows": []}
+        records = parse_table_data(table, "test")
+        assert records == []
+
+    def test_source_url_set(self, sample_table):
+        records = parse_table_data(sample_table, "my_source")
+        assert all(r.source_url == "my_source" for r in records)
+
+
+class TestParseCssRows:
+    """Tests for JsonCssExtractionStrategy output parsing."""
+
+    @pytest.fixture
+    def sample_rows(self):
+        return [
+            {
+                "serial": "1",
+                "case": "W.P No. 1395-M of 2019 Sayyed Mukammal Shah  Vs  Mst. Nasira and others",
+                "remarks": "Relinquishment of dower by the wife",
+                "other_citation": "awaited",
+                "neutral_citation": "",
+                "decision_date": "23-12-2024",
+                "sc_status": "",
+                "category": "Constitutional",
+                "pdf_url": "https://www.peshawarhighcourt.gov.pk/PHCCMS//judgments/W.P-No.-1395-M-of-2019.pdf",
+                "sc_pdf_url": "",
+            },
+            {
+                "serial": "2",
+                "case": "Cr.A No. 100-P of 2024 State Vs Accused",
+                "remarks": "Murder appeal",
+                "other_citation": "2024 PCrLJ 500",
+                "neutral_citation": "2024 PHC 123",
+                "decision_date": "15-06-2024",
+                "sc_status": "Dismissed",
+                "category": "Criminal",
+                "pdf_url": "https://www.peshawarhighcourt.gov.pk/PHCCMS//judgments/cra100.pdf",
+                "sc_pdf_url": "https://www.peshawarhighcourt.gov.pk/sc-judgment.pdf",
+            },
+        ]
+
+    def test_parses_records(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source")
+        assert len(records) == 2
+        assert all(isinstance(r, JudgmentRecord) for r in records)
+
+    def test_pdf_urls_captured(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source")
+        assert records[0].pdf_url.endswith(".pdf")
+        assert "peshawarhighcourt" in records[0].pdf_url
+        assert records[1].sc_pdf_url.endswith(".pdf")
+
+    def test_case_number_parsed(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source")
+        assert records[0].case_number == "W.P No. 1395-M of 2019"
+        assert records[1].case_number == "Cr.A No. 100-P of 2024"
+
+    def test_criminal_category(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source")
+        assert records[1].category == "Criminal"
+        assert records[1].sc_status == "Dismissed"
+
+    def test_empty_list(self):
+        records = parse_css_rows([], "test")
+        assert records == []
+
+    def test_missing_fields(self):
+        rows = [{"serial": "1", "case": "Test of 2024 Foo Vs Bar"}]
+        records = parse_css_rows(rows, "test")
+        assert len(records) == 1
+        assert records[0].pdf_url == ""
+        assert records[0].category == ""

--- a/tests/test_shared_components.py
+++ b/tests/test_shared_components.py
@@ -102,6 +102,18 @@ class TestJudgeExtractor:
         names = extract_judge_names(text)
         assert len(names) == len(set(names))
 
+    def test_all_caps_names(self):
+        text = "PRESENT: MR. JUSTICE IFTIKHAR CHAUDHRY, MR. JUSTICE ANWAR ZAHEER JAMALI"
+        names = extract_judge_names(text)
+        assert len(names) >= 2
+        assert any("Iftikhar" in n for n in names)
+
+    def test_none_input(self):
+        assert extract_judge_names(None) == []
+
+    def test_empty_string(self):
+        assert extract_judge_names("") == []
+
 
 # ── Quality Validator ─────────────────────────────────────────────────────
 
@@ -150,10 +162,11 @@ class TestQualityValidator:
             "field_a": None,
             "field_b": "",
             "field_c": [],
+            "field_d": 0,  # numeric 0 counts as filled
         }
         report = validate_extraction(text, payload)
-        # 2 filled out of 5 = 40%
-        assert report.field_coverage == 40.0
+        # 3 filled (X, Y, 0) out of 6 = 50%
+        assert report.field_coverage == 50.0
 
     def test_consistency_diyat_conviction(self):
         text = "x" * 1000
@@ -165,6 +178,11 @@ class TestQualityValidator:
         }
         report = validate_extraction(text, payload)
         assert any("diyat" in w for w in report.warnings)
+
+    def test_none_payload(self):
+        report = validate_extraction("x" * 1000, None)
+        assert not report.passed
+        assert any("None" in e for e in report.errors)
 
 
 # ── Dedup ─────────────────────────────────────────────────────────────────
@@ -186,6 +204,12 @@ class TestDedup:
         # Different whitespace should produce same hash
         assert text_hash("hello  world") == text_hash("hello world")
         assert text_hash("  hello world  ") == text_hash("hello world")
+
+    def test_text_hash_empty_raises(self):
+        with pytest.raises(ValueError, match="empty text"):
+            text_hash("")
+        with pytest.raises(ValueError, match="empty text"):
+            text_hash("   ")
 
     def test_text_hash_case_insensitive(self):
         assert text_hash("Hello World") == text_hash("hello world")
@@ -248,6 +272,14 @@ class TestRateLimiter:
             limiter.wait()
         assert limiter.request_count == 5
 
+    def test_zero_rate_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            RateLimiter(requests_per_second=0.0)
+
+    def test_negative_rate_raises(self):
+        with pytest.raises(ValueError, match="positive"):
+            RateLimiter(requests_per_second=-1.0)
+
 
 # ── Section Splitter ──────────────────────────────────────────────────────
 
@@ -261,7 +293,7 @@ class TestSectionSplitter:
 
     def test_empty_text(self):
         result = split_judgment("")
-        assert result == {"full_text": ""}
+        assert result == {"full_text": "", "header": ""}
 
     def test_detects_facts_section(self):
         text = (


### PR DESCRIPTION
## Summary
- Full crawl4ai pipeline for PHC reported judgments (5,590 across 2010-2026)
- Two-step session approach: form submit with navigation handling + DataTable expansion via js_only
- JsonCssExtractionStrategy captures all 10 table columns including PDF href attributes
- Client-side category filtering (PHC server returns HTTP 500 for category filter)
- Pipeline orchestrator with checkpoint saves, dedup, and per-record error isolation
- 26 offline unit tests, minor fixes to shared extraction components

## Data Quality (verified on 258 records, year=2024)
| Metric | Coverage |
|--------|----------|
| PDF URL | 100% |
| Date parsing | 100% |
| Case number | 99.2% |
| Case title | 99.2% |
| Remarks/headnotes | 99.2% |

## Known Limitations
- PHC PDFs are scanned images (no embedded text) — OCR needed for text extraction
- Category filter broken server-side (HTTP 500) — handled via client-side filtering
- `wait_until="networkidle"` used instead of CSS selector wait due to intermittent SSL issues

## Test plan
- [x] 26 offline unit tests pass (parsing, date handling, CSS rows, table data)
- [x] Live crawl verified: 258 records for 2024, all categories present
- [x] Category filter verified: 83 Criminal records correctly filtered client-side
- [x] PDF download tested: files download successfully (scanned images confirmed)

Closes #5