### PR TITLE
Add Sindh High Court crawler pipeline (#3)

### DIFF
--- a/src/pipelines/sindh_hc/constants.py
+++ b/src/pipelines/sindh_hc/constants.py
@@ -1,0 +1,56 @@
+"""Shared constants for the Sindh High Court crawler pipeline."""
+
+BASE_URL = "https://caselaw.shc.gov.pk/caselaw"
+
+# Public report page listing all judges with judgment counts
+JUDGES_REPORT_URL = f"{BASE_URL}/public/rpt-afr"
+
+# URL template for individual judge's judgments. Params: judge_id, filter.
+# filter = "-1" for all, "AFR/AFR" for approved-for-reporting only.
+JUDGE_JUDGMENTS_URL_TEMPLATE = (
+    f"{BASE_URL}/public/reported-judgements-detail-all/{{judge_id}}/{{filter}}"
+)
+
+# PDF download URL pattern (relative to BASE_URL)
+PDF_DOWNLOAD_URL = f"{BASE_URL}/public/download-file.php"
+
+# Court code used in Qdrant point IDs
+COURT_CODE = "SHC"
+
+# Known judge IDs from recon (as of March 2026)
+# Maps judge_id -> judge name for reference
+JUDGE_IDS = {
+    844: "Zafar Ahmed Rajput",
+    883: "Muhammad Iqbal Kalhoro",
+    965: "Mahmood A. Khan",
+    966: "Muhammad Faisal Kamal Alam",
+    1023: "Muhammad Saleem Jessar",
+    1041: "Arshad Hussain Khan",
+    1061: "Adnan-ul-Karim Memon",
+    1101: "Khadim Hussain Tunio",
+    1102: "Yousuf Ali Sayeed",
+    1121: "Omar Sial",
+    1162: "Shamsuddin Abbasi",
+    1181: "Agha Faisal",
+    1182: "Amjad Ali Sahito",
+    1201: "Adnan Iqbal Chaudhry",
+    1242: "Abdul Mobeen Lakho",
+    1243: "Zulfiqar Ali Sangi",
+    1261: "Amjad Ali Bohio",
+    1263: "Sana Akram Minhas",
+    1264: "Jawad Akbar Sarwana",
+    1266: "Muhammad Abdur Rahman",
+    1267: "Arbab Ali Hakro",
+    1301: "Miran Muhammad Shah",
+    1302: "Tasneem Sultana",
+    1303: "Riazat Ali Sahar",
+    1304: "Muhammad Hasan (Akber)",
+    1305: "Khalid Hussain Shahani",
+    1306: "Abdul Hamid Bhurgri",
+    1307: "Syed Fiaz Ul Hassan Shah",
+    1308: "Jan Ali Junejo",
+    1309: "Nisar Ahmed Bhanbhro",
+    1310: "Ali Haider 'Ada'",
+    1311: "Muhammad Osman Ali Hadi",
+    1312: "Muhammad Jaffer Raza",
+}

--- a/src/pipelines/sindh_hc/errors.py
+++ b/src/pipelines/sindh_hc/errors.py
@@ -1,0 +1,9 @@
+"""Custom exceptions for the Sindh HC crawler pipeline."""
+
+
+class CrawlError(Exception):
+    """Raised when a crawl operation fails irrecoverably."""
+
+
+class ExtractionError(Exception):
+    """Raised when data extraction from HTML/PDF fails."""

--- a/src/pipelines/sindh_hc/listing.py
+++ b/src/pipelines/sindh_hc/listing.py
@@ -1,0 +1,417 @@
+"""Crawl Sindh HC caselaw database and extract judgment metadata.
+
+Single responsibility: page load + DataTable HTML -> list of JudgmentRecord.
+
+The SHC caselaw site (caselaw.shc.gov.pk) organizes judgments by judge.
+Each judge has a public page listing all their judgments in a jQuery DataTable.
+
+Data source: https://caselaw.shc.gov.pk/caselaw/public/rpt-afr
+    - Lists all judges with judgment counts
+    - Each judge links to: reported-judgements-detail-all/{judge_id}/-1
+
+Table columns (0-indexed):
+  0: S.No.
+  1: Citation (e.g. "2023 SHC KHI 1139" or "Nil")
+  2: Case No. (e.g. "Criminal Appeal 91/2023 (S.B.)")
+  3: Case Type (e.g. "Original Side", "Criminal Appellate Jurisdictions")
+  4: Case Year
+  5: Parties (e.g. "Umair Qadeer v. Muhammad Nasir & Another")
+  6: Order_Date (DD-MMM-YY format, e.g. "15-MAY-23")
+  7: A.F.R (Yes/No)
+  8: Head Notes/Tag Line
+  9: Bench (judge names)
+  10: Apex Court
+  11: Apex Status
+
+PDF links: Case No. column contains <a href="download-file.php?doc=...&citation=...">
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import date, datetime
+from urllib.parse import urljoin
+
+from pydantic import BaseModel
+
+from .constants import BASE_URL, JUDGE_JUDGMENTS_URL_TEMPLATE, JUDGES_REPORT_URL
+from .errors import CrawlError
+
+logger = logging.getLogger(__name__)
+
+
+class JudgmentRecord(BaseModel):
+    """A single judgment row extracted from the SHC caselaw DataTable."""
+
+    serial: int
+    citation: str
+    case_number: str
+    case_type: str
+    case_year: str
+    parties: str
+    order_date: str
+    order_date_parsed: date | None = None
+    afr: str
+    head_notes: str
+    bench: str
+    apex_court: str
+    apex_status: str
+    pdf_url: str
+    judge_id: int
+    judge_name: str
+    source_url: str
+
+
+def _parse_date(raw: str) -> date | None:
+    """Parse DD-MMM-YY date string (e.g. '15-MAY-23')."""
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        return datetime.strptime(raw, "%d-%b-%y").date()
+    except ValueError:
+        pass
+    # Try full year format DD-MMM-YYYY
+    try:
+        return datetime.strptime(raw, "%d-%b-%Y").date()
+    except ValueError:
+        pass
+    logger.debug("Could not parse date: %s", raw)
+    return None
+
+
+def _parse_case_number(raw: str) -> str:
+    """Clean case number text (strip whitespace, normalize spaces)."""
+    return re.sub(r"\s+", " ", raw.strip())
+
+
+def _resolve_pdf_url(relative_url: str) -> str:
+    """Resolve a relative PDF download URL to absolute.
+
+    The SHC caselaw site uses <base href="/caselaw/"> so all relative hrefs
+    resolve from https://caselaw.shc.gov.pk/caselaw/.
+    """
+    if not relative_url:
+        return ""
+    relative_url = relative_url.strip()
+    if relative_url.startswith("http"):
+        return relative_url
+    # Resolve relative to <base href="/caselaw/">
+    return urljoin(BASE_URL + "/", relative_url)
+
+
+# JsonCssExtractionStrategy schema for the SHC DataTable rows.
+# Captures PDF links (as href attributes on case number <a> tags).
+CSS_EXTRACTION_SCHEMA = {
+    "name": "SHC Judgments",
+    "baseSelector": ".hasDataTable tbody tr",
+    "fields": [
+        {"name": "serial", "selector": "td:nth-child(1)", "type": "text"},
+        {"name": "citation", "selector": "td:nth-child(2)", "type": "text"},
+        {"name": "case_number", "selector": "td:nth-child(3)", "type": "text"},
+        {
+            "name": "pdf_url",
+            "selector": "td:nth-child(3) a",
+            "type": "attribute",
+            "attribute": "href",
+        },
+        {"name": "case_type", "selector": "td:nth-child(4)", "type": "text"},
+        {"name": "case_year", "selector": "td:nth-child(5)", "type": "text"},
+        {"name": "parties", "selector": "td:nth-child(6)", "type": "text"},
+        {"name": "order_date", "selector": "td:nth-child(7)", "type": "text"},
+        {"name": "afr", "selector": "td:nth-child(8)", "type": "text"},
+        {"name": "head_notes", "selector": "td:nth-child(9)", "type": "text"},
+        {"name": "bench", "selector": "td:nth-child(10)", "type": "text"},
+        {"name": "apex_court", "selector": "td:nth-child(11)", "type": "text"},
+        {"name": "apex_status", "selector": "td:nth-child(12)", "type": "text"},
+    ],
+}
+
+# Schema for the judges report page (rpt-afr)
+JUDGES_CSS_SCHEMA = {
+    "name": "SHC Judges",
+    "baseSelector": "table tbody tr",
+    "fields": [
+        {"name": "serial", "selector": "td:nth-child(1)", "type": "text"},
+        {"name": "judge_name", "selector": "td:nth-child(2)", "type": "text"},
+        {
+            "name": "total_url",
+            "selector": "td:nth-child(3) a",
+            "type": "attribute",
+            "attribute": "href",
+        },
+        {"name": "total", "selector": "td:nth-child(3)", "type": "text"},
+        {
+            "name": "afr_url",
+            "selector": "td:nth-child(4) a",
+            "type": "attribute",
+            "attribute": "href",
+        },
+        {"name": "afr", "selector": "td:nth-child(4)", "type": "text"},
+    ],
+}
+
+
+def parse_css_rows(
+    raw_rows: list[dict],
+    source_url: str,
+    judge_id: int,
+    judge_name: str,
+) -> list[JudgmentRecord]:
+    """Parse rows from JsonCssExtractionStrategy into JudgmentRecord models."""
+    records = []
+    for row in raw_rows:
+        order_date_raw = row.get("order_date", "").strip()
+        pdf_url_raw = row.get("pdf_url", "").strip()
+
+        record = JudgmentRecord(
+            serial=int(row.get("serial", 0) or 0),
+            citation=row.get("citation", "").strip(),
+            case_number=_parse_case_number(row.get("case_number", "")),
+            case_type=row.get("case_type", "").strip(),
+            case_year=row.get("case_year", "").strip(),
+            parties=row.get("parties", "").strip(),
+            order_date=order_date_raw,
+            order_date_parsed=_parse_date(order_date_raw),
+            afr=row.get("afr", "").strip(),
+            head_notes=row.get("head_notes", "").strip(),
+            bench=row.get("bench", "").strip(),
+            apex_court=row.get("apex_court", "").strip(),
+            apex_status=row.get("apex_status", "").strip(),
+            pdf_url=_resolve_pdf_url(pdf_url_raw),
+            judge_id=judge_id,
+            judge_name=judge_name,
+            source_url=source_url,
+        )
+        records.append(record)
+
+    return records
+
+
+def parse_judge_rows(raw_rows: list[dict]) -> list[dict]:
+    """Parse the judges report table into judge info dicts.
+
+    Returns list of dicts with keys: judge_id, judge_name, total, afr.
+    """
+    judges = []
+    for row in raw_rows:
+        # Extract judge_id from the total_url (pattern: .../{judge_id}/-1)
+        total_url = row.get("total_url", "")
+        match = re.search(r"/(\d+)/-1", total_url)
+        if not match:
+            continue
+
+        judge_id = int(match.group(1))
+        judge_name = row.get("judge_name", "").strip()
+        total_str = row.get("total", "").strip().replace(",", "")
+        afr_str = row.get("afr", "").strip().replace(",", "")
+
+        judges.append({
+            "judge_id": judge_id,
+            "judge_name": judge_name,
+            "total": int(total_str) if total_str.isdigit() else 0,
+            "afr": int(afr_str) if afr_str.isdigit() else 0,
+        })
+
+    return judges
+
+
+async def crawl_judges_list() -> list[dict]:
+    """Crawl the judges report page to get all judge IDs and names.
+
+    Returns list of dicts with keys: judge_id, judge_name, total, afr.
+
+    Raises:
+        CrawlError: If the page cannot be loaded or extraction fails.
+    """
+    from crawl4ai import (
+        AsyncWebCrawler,
+        BrowserConfig,
+        CacheMode,
+        CrawlerRunConfig,
+        JsonCssExtractionStrategy,
+    )
+
+    browser_config = BrowserConfig(
+        headless=True,
+        extra_args=["--ignore-certificate-errors"],
+    )
+
+    extraction_strategy = JsonCssExtractionStrategy(
+        schema=JUDGES_CSS_SCHEMA, verbose=False,
+    )
+
+    config = CrawlerRunConfig(
+        cache_mode=CacheMode.BYPASS,
+        wait_until="networkidle",
+        wait_for="css:.hasDataTable",
+        delay_before_return_html=2.0,
+        extraction_strategy=extraction_strategy,
+        page_timeout=60000,
+    )
+
+    async with AsyncWebCrawler(config=browser_config) as crawler:
+        result = await crawler.arun(url=JUDGES_REPORT_URL, config=config)
+        if not result.success:
+            raise CrawlError(f"Failed to load judges report: {result.error_message}")
+
+        if not result.extracted_content:
+            raise CrawlError("No data extracted from judges report page")
+
+        try:
+            raw_rows = json.loads(result.extracted_content)
+        except json.JSONDecodeError as e:
+            raise CrawlError(f"Failed to parse judges JSON: {e}") from e
+
+    judges = parse_judge_rows(raw_rows)
+    logger.info("Found %d judges on SHC caselaw site", len(judges))
+    return judges
+
+
+async def crawl_judge_judgments(
+    judge_id: int,
+    judge_name: str,
+    afr_only: bool = False,
+) -> list[JudgmentRecord]:
+    """Crawl all judgments for a specific judge.
+
+    The SHC caselaw site loads ALL judgments for a judge on a single page
+    in a jQuery DataTable. We need to expand the table to show all rows
+    before extracting.
+
+    Args:
+        judge_id: Numeric judge identifier.
+        judge_name: Judge's display name for record metadata.
+        afr_only: If True, only crawl AFR (approved for reporting) judgments.
+
+    Returns:
+        List of JudgmentRecord extracted from the judge's page.
+
+    Raises:
+        CrawlError: If the page cannot be loaded or extraction fails.
+    """
+    from crawl4ai import (
+        AsyncWebCrawler,
+        BrowserConfig,
+        CacheMode,
+        CrawlerRunConfig,
+        JsonCssExtractionStrategy,
+    )
+
+    filter_value = "AFR/AFR" if afr_only else "-1"
+    url = JUDGE_JUDGMENTS_URL_TEMPLATE.format(
+        judge_id=judge_id, filter=filter_value,
+    )
+
+    browser_config = BrowserConfig(
+        headless=True,
+        extra_args=["--ignore-certificate-errors"],
+    )
+
+    # JavaScript to expand DataTable to show all rows.
+    # The table uses jQuery DataTable with length menu [10, 25, 50, "All"].
+    # We set page length to -1 (all) and redraw.
+    expand_datatable_js = """
+    (async () => {
+        // Poll until DataTable is initialized (up to 15s)
+        for (let i = 0; i < 30; i++) {
+            if (typeof $ !== 'undefined' && $.fn.DataTable
+                && $.fn.DataTable.isDataTable('.hasDataTable')) {
+                const dt = $('.hasDataTable').DataTable();
+                dt.page.len(-1).draw();
+                await new Promise(r => setTimeout(r, 1000));
+                return;
+            }
+            await new Promise(r => setTimeout(r, 500));
+        }
+    })();
+    """
+
+    extraction_strategy = JsonCssExtractionStrategy(
+        schema=CSS_EXTRACTION_SCHEMA, verbose=False,
+    )
+
+    session_id = f"shc_judge_{judge_id}"
+
+    async with AsyncWebCrawler(config=browser_config) as crawler:
+        # Step 1: Load the page and wait for DataTable
+        step1_config = CrawlerRunConfig(
+            session_id=session_id,
+            cache_mode=CacheMode.BYPASS,
+            wait_until="networkidle",
+            wait_for="css:.hasDataTable",
+            delay_before_return_html=3.0,
+            page_timeout=90000,
+        )
+        result = await crawler.arun(url=url, config=step1_config)
+        if not result.success:
+            raise CrawlError(
+                f"Failed to load judge page {judge_id}: {result.error_message}"
+            )
+
+        # Step 2: Expand DataTable to show all rows and extract
+        step2_config = CrawlerRunConfig(
+            session_id=session_id,
+            cache_mode=CacheMode.BYPASS,
+            js_only=True,
+            js_code=expand_datatable_js,
+            delay_before_return_html=3.0,
+            extraction_strategy=extraction_strategy,
+            page_timeout=60000,
+        )
+        result = await crawler.arun(url=url, config=step2_config)
+
+        if not result.success:
+            raise CrawlError(
+                f"Data extraction failed for judge {judge_id}: {result.error_message}"
+            )
+
+        records = []
+        if result.extracted_content:
+            try:
+                raw_rows = json.loads(result.extracted_content)
+                records = parse_css_rows(raw_rows, url, judge_id, judge_name)
+            except json.JSONDecodeError as e:
+                raise CrawlError(f"Failed to parse extracted JSON: {e}") from e
+
+    if not records:
+        logger.warning(
+            "No records found for judge %s (ID=%d)", judge_name, judge_id,
+        )
+
+    logger.info(
+        "Crawled %d judgment records for judge %s (ID=%d)",
+        len(records), judge_name, judge_id,
+    )
+    return records
+
+
+async def crawl_all_judges() -> list[JudgmentRecord]:
+    """Crawl judgments for all judges listed on the SHC caselaw site.
+
+    First fetches the judges list, then crawls each judge's page sequentially.
+    """
+    judges = await crawl_judges_list()
+    all_records: list[JudgmentRecord] = []
+
+    for judge in judges:
+        try:
+            records = await crawl_judge_judgments(
+                judge_id=judge["judge_id"],
+                judge_name=judge["judge_name"],
+            )
+            all_records.extend(records)
+            logger.info(
+                "Judge %s: %d records (running total: %d)",
+                judge["judge_name"], len(records), len(all_records),
+            )
+        except CrawlError as e:
+            logger.error(
+                "Failed to crawl judge %s (ID=%d): %s",
+                judge["judge_name"], judge["judge_id"], e,
+            )
+
+    logger.info("Total: %d judgment records from %d judges", len(all_records), len(judges))
+    return all_records

--- a/src/pipelines/sindh_hc/pipeline.py
+++ b/src/pipelines/sindh_hc/pipeline.py
@@ -1,0 +1,287 @@
+"""Sindh High Court crawler pipeline.
+
+Orchestrates the full flow: judge listing → judgment extraction → PDF download → text output.
+Single responsibility: coordinate the pipeline stages with crash resilience.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+
+from src.extractors.common.pdf_extract import download_and_extract
+
+from .constants import COURT_CODE, JUDGE_IDS
+from .listing import JudgmentRecord, crawl_all_judges, crawl_judge_judgments
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OUTPUT_DIR = Path(
+    os.environ.get("SHC_OUTPUT_DIR", "data/sindh_hc")
+)
+
+CHECKPOINT_INTERVAL = 25
+
+
+async def crawl_full(
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    limit: int | None = None,
+    judge_id: int | None = None,
+    afr_only: bool = False,
+) -> list[dict]:
+    """Crawl SHC caselaw judgments and extract PDF text.
+
+    Args:
+        output_dir: Directory to save results and PDFs.
+        limit: Max number of judgments to process. None for all.
+        judge_id: Crawl only this judge's judgments. None for all judges.
+        afr_only: If True, only crawl AFR (approved for reporting) judgments.
+
+    Returns:
+        List of result dicts with metadata + extracted text.
+
+    Raises:
+        CrawlError: If the listing page cannot be crawled.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    pdf_dir = output_dir / "pdfs"
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+
+    # Stage 1: Get judgment records
+    if judge_id is not None:
+        judge_name = JUDGE_IDS.get(judge_id, f"Judge {judge_id}")
+        logger.info(
+            "Stage 1: Crawling judgments for judge %s (ID=%d)...",
+            judge_name, judge_id,
+        )
+        records = await crawl_judge_judgments(
+            judge_id=judge_id,
+            judge_name=judge_name,
+            afr_only=afr_only,
+        )
+    else:
+        logger.info("Stage 1: Crawling judgments for ALL judges...")
+        records = await crawl_all_judges()
+
+    logger.info("Found %d judgment records", len(records))
+
+    if limit:
+        records = records[:limit]
+        logger.info("Limited to %d records", limit)
+
+    # Stage 2: Download PDFs and extract text
+    results = await _process_records(records, pdf_dir)
+
+    # Save results
+    _save_results(results, output_dir / "results.jsonl")
+    _save_summary(results, output_dir / "summary.json")
+    return results
+
+
+async def crawl_judge(
+    judge_id: int,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    limit: int | None = None,
+    afr_only: bool = False,
+) -> list[dict]:
+    """Crawl judgments for a single SHC judge."""
+    return await crawl_full(
+        output_dir=output_dir,
+        limit=limit,
+        judge_id=judge_id,
+        afr_only=afr_only,
+    )
+
+
+async def _process_records(
+    records: list[JudgmentRecord],
+    pdf_dir: Path,
+) -> list[dict]:
+    """Download PDFs and extract text for each judgment record.
+
+    Per-record error isolation so one failure doesn't kill the batch.
+    Checkpoint saves every CHECKPOINT_INTERVAL records.
+    """
+    results: list[dict] = []
+    seen_urls: set[str] = set()
+    checkpoint_path = pdf_dir.parent / "checkpoint.jsonl"
+    failed_count = 0
+
+    for idx, record in enumerate(records):
+        # Deduplicate by PDF URL
+        if record.pdf_url and record.pdf_url in seen_urls:
+            logger.debug("Skipping duplicate PDF: %s", record.pdf_url)
+            continue
+        if record.pdf_url:
+            seen_urls.add(record.pdf_url)
+
+        try:
+            result = await _process_single_record(record, pdf_dir)
+            results.append(result)
+
+            if result["text"]:
+                logger.info(
+                    "[%d/%d] OK: %s — %d chars",
+                    idx + 1, len(records),
+                    record.case_number or "?",
+                    result["text_length"],
+                )
+            else:
+                logger.warning(
+                    "[%d/%d] EMPTY: %s — no text extracted",
+                    idx + 1, len(records),
+                    record.case_number or record.pdf_url,
+                )
+
+        except Exception as e:
+            failed_count += 1
+            logger.error(
+                "[%d/%d] FAILED: %s: %s",
+                idx + 1, len(records), record.case_number, e,
+                exc_info=True,
+            )
+            results.append({
+                **record.model_dump(),
+                "text": "",
+                "text_length": 0,
+                "error": str(e),
+                "source": "sindh_hc",
+                "court": COURT_CODE,
+            })
+
+        # Checkpoint save
+        if len(results) % CHECKPOINT_INTERVAL == 0 and results:
+            _save_results(results, checkpoint_path)
+            logger.info("Checkpoint: %d results saved", len(results))
+
+    with_text = sum(1 for r in results if r["text"])
+    logger.info(
+        "Processed %d records: %d with text, %d empty, %d failed",
+        len(results), with_text, len(results) - with_text - failed_count, failed_count,
+    )
+    return results
+
+
+async def _process_single_record(
+    record: JudgmentRecord,
+    pdf_dir: Path,
+) -> dict:
+    """Download PDF and extract text for a single judgment record."""
+    text = ""
+    if record.pdf_url:
+        text = await download_and_extract(record.pdf_url, pdf_dir)
+    else:
+        logger.warning("No PDF URL for %s", record.case_number)
+
+    return {
+        **record.model_dump(),
+        "text": text,
+        "text_length": len(text),
+        "source": "sindh_hc",
+        "court": COURT_CODE,
+    }
+
+
+def _save_results(results: list[dict], path: Path) -> None:
+    """Save results as JSONL."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(path, "w") as f:
+            for result in results:
+                # Convert date objects to strings for JSON serialization
+                row = {}
+                for k, v in result.items():
+                    if hasattr(v, "isoformat"):
+                        row[k] = v.isoformat()
+                    else:
+                        row[k] = v
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+        logger.info("Saved %d results to %s", len(results), path)
+    except (OSError, TypeError) as e:
+        logger.error("Failed to save results to %s: %s", path, e)
+        raise
+
+
+def _save_summary(results: list[dict], path: Path) -> None:
+    """Save a summary of the crawl run."""
+    with_text = sum(1 for r in results if r.get("text"))
+    errors = sum(1 for r in results if r.get("error"))
+
+    by_case_type: dict[str, int] = {}
+    for r in results:
+        ct = r.get("case_type", "unknown")
+        by_case_type[ct] = by_case_type.get(ct, 0) + 1
+
+    by_judge: dict[str, int] = {}
+    for r in results:
+        jn = r.get("judge_name", "unknown")
+        by_judge[jn] = by_judge.get(jn, 0) + 1
+
+    summary = {
+        "total_records": len(results),
+        "with_text": with_text,
+        "empty_text": len(results) - with_text,
+        "errors": errors,
+        "by_case_type": by_case_type,
+        "by_judge": by_judge,
+        "records": [
+            {
+                "case_number": r.get("case_number"),
+                "citation": r.get("citation"),
+                "case_type": r.get("case_type"),
+                "order_date": r.get("order_date"),
+                "judge_name": r.get("judge_name"),
+                "text_length": r.get("text_length", 0),
+                "error": r.get("error"),
+            }
+            for r in results
+        ],
+    }
+    try:
+        with open(path, "w") as f:
+            json.dump(summary, f, indent=2, ensure_ascii=False)
+    except (OSError, TypeError) as e:
+        logger.error("Failed to save summary to %s: %s", path, e)
+
+
+async def main():
+    """CLI entry point."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Sindh High Court Judgment Crawler")
+    parser.add_argument(
+        "--judge-id", type=int, default=None,
+        help="Crawl only this judge's judgments (numeric ID)",
+    )
+    parser.add_argument(
+        "--afr-only", action="store_true",
+        help="Only crawl AFR (approved for reporting) judgments",
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Max judgments to process")
+    parser.add_argument("--output", type=str, default=str(DEFAULT_OUTPUT_DIR))
+    args = parser.parse_args()
+
+    output_dir = Path(args.output)
+
+    results = await crawl_full(
+        output_dir=output_dir,
+        limit=args.limit,
+        judge_id=args.judge_id,
+        afr_only=args.afr_only,
+    )
+
+    with_text = sum(1 for r in results if r["text"])
+    errors = sum(1 for r in results if r.get("error"))
+    logger.info("Done: %d records, %d with text, %d errors", len(results), with_text, errors)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_sindh_hc.py
+++ b/tests/test_sindh_hc.py
@@ -1,0 +1,338 @@
+"""Tests for the Sindh HC crawler pipeline.
+
+Tests parsing logic with real sample data from SHC caselaw website recon.
+Does NOT hit the live website — all tests use offline sample data.
+"""
+
+from datetime import date
+
+import pytest
+
+from src.pipelines.sindh_hc.listing import (
+    JudgmentRecord,
+    _parse_case_number,
+    _parse_date,
+    _resolve_pdf_url,
+    parse_css_rows,
+    parse_judge_rows,
+)
+
+
+class TestParseDate:
+    def test_standard_date_short_year(self):
+        assert _parse_date("15-MAY-23") == date(2023, 5, 15)
+
+    def test_standard_date_full_year(self):
+        assert _parse_date("22-AUG-2019") == date(2019, 8, 22)
+
+    def test_january(self):
+        assert _parse_date("26-JAN-24") == date(2024, 1, 26)
+
+    def test_december(self):
+        assert _parse_date("31-DEC-22") == date(2022, 12, 31)
+
+    def test_empty(self):
+        assert _parse_date("") is None
+
+    def test_whitespace(self):
+        assert _parse_date("  15-MAY-23  ") == date(2023, 5, 15)
+
+    def test_invalid(self):
+        assert _parse_date("not-a-date") is None
+
+    def test_partial(self):
+        assert _parse_date("15-MAY") is None
+
+
+class TestParseCaseNumber:
+    def test_standard(self):
+        assert _parse_case_number("Criminal Appeal 91/2023 (S.B.)") == "Criminal Appeal 91/2023 (S.B.)"
+
+    def test_extra_whitespace(self):
+        assert _parse_case_number("  Const.  P.  1608/2015  ") == "Const. P. 1608/2015"
+
+    def test_empty(self):
+        assert _parse_case_number("") == ""
+
+
+class TestResolvePdfUrl:
+    def test_relative_url(self):
+        url = _resolve_pdf_url("download-file.php?doc=MTk0ODc3&citation=2023+SHC+KHI+1139")
+        assert url == "https://caselaw.shc.gov.pk/caselaw/download-file.php?doc=MTk0ODc3&citation=2023+SHC+KHI+1139"
+
+    def test_absolute_url(self):
+        url = _resolve_pdf_url("https://example.com/file.pdf")
+        assert url == "https://example.com/file.pdf"
+
+    def test_empty(self):
+        assert _resolve_pdf_url("") == ""
+
+    def test_whitespace(self):
+        url = _resolve_pdf_url("  download-file.php?doc=abc  ")
+        assert "download-file.php" in url
+
+
+class TestParseCssRows:
+    """Tests for JsonCssExtractionStrategy output parsing."""
+
+    @pytest.fixture
+    def sample_rows(self):
+        return [
+            {
+                "serial": "1",
+                "citation": "2023 SHC KHI 1139",
+                "case_number": "Criminal Appeal 91/2023 (S.B.)",
+                "pdf_url": "download-file.php?doc=MTk0ODc3Y2Ztcy1kYzgz&citation=2023+SHC+KHI+1139",
+                "case_type": "Original Side",
+                "case_year": "2023",
+                "parties": "Umair Qadeer v. Muhammad Nasir & Another",
+                "order_date": "15-MAY-23",
+                "afr": "Yes",
+                "head_notes": "Challenge to show cause notice",
+                "bench": "Hon'ble Mr. Justice Amjad Ali Bohio(Author)",
+                "apex_court": "",
+                "apex_status": "",
+            },
+            {
+                "serial": "2",
+                "citation": "2023 SBLR Sindh 1613",
+                "case_number": "Criminal Appeal 582/2022 (S.B.)",
+                "pdf_url": "download-file.php?doc=abc123&citation=2023+SBLR+Sindh+1613",
+                "case_type": "Original Side",
+                "case_year": "2022",
+                "parties": "Zainab Bibi v. Syed Kamal Shah & Another",
+                "order_date": "18-MAY-23",
+                "afr": "No",
+                "head_notes": "Family matter",
+                "bench": "Hon'ble Mr. Justice Amjad Ali Bohio(Author)",
+                "apex_court": "Supreme Court",
+                "apex_status": "Dismissed",
+            },
+            {
+                "serial": "3",
+                "citation": "Nil",
+                "case_number": "R.A (Civil Revision) 12/2023 (S.B.)",
+                "pdf_url": "",
+                "case_type": "Civil Appellate Jurisdictions",
+                "case_year": "2023",
+                "parties": "Basit Ahmed v. Shakeel & Others",
+                "order_date": "26-JAN-24",
+                "afr": "No",
+                "head_notes": "",
+                "bench": "Hon'ble Mr. Justice Amjad Ali Bohio(Author)",
+                "apex_court": "",
+                "apex_status": "",
+            },
+        ]
+
+    def test_parses_records(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source", 1261, "Amjad Ali Bohio")
+        assert len(records) == 3
+        assert all(isinstance(r, JudgmentRecord) for r in records)
+
+    def test_case_number_parsed(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source", 1261, "Amjad Ali Bohio")
+        assert records[0].case_number == "Criminal Appeal 91/2023 (S.B.)"
+        assert records[2].case_number == "R.A (Civil Revision) 12/2023 (S.B.)"
+
+    def test_citation_captured(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source", 1261, "Amjad Ali Bohio")
+        assert records[0].citation == "2023 SHC KHI 1139"
+        assert records[1].citation == "2023 SBLR Sindh 1613"
+        assert records[2].citation == "Nil"
+
+    def test_date_parsed(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source", 1261, "Amjad Ali Bohio")
+        assert records[0].order_date_parsed == date(2023, 5, 15)
+        assert records[0].order_date == "15-MAY-23"
+
+    def test_pdf_url_resolved(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source", 1261, "Amjad Ali Bohio")
+        assert records[0].pdf_url.startswith("https://caselaw.shc.gov.pk")
+        assert "download-file.php" in records[0].pdf_url
+
+    def test_empty_pdf_url(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source", 1261, "Amjad Ali Bohio")
+        assert records[2].pdf_url == ""
+
+    def test_case_type(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source", 1261, "Amjad Ali Bohio")
+        assert records[0].case_type == "Original Side"
+        assert records[2].case_type == "Civil Appellate Jurisdictions"
+
+    def test_parties(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source", 1261, "Amjad Ali Bohio")
+        assert "Umair Qadeer" in records[0].parties
+        assert "Muhammad Nasir" in records[0].parties
+
+    def test_afr_field(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source", 1261, "Amjad Ali Bohio")
+        assert records[0].afr == "Yes"
+        assert records[1].afr == "No"
+
+    def test_apex_court(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source", 1261, "Amjad Ali Bohio")
+        assert records[1].apex_court == "Supreme Court"
+        assert records[1].apex_status == "Dismissed"
+        assert records[0].apex_court == ""
+
+    def test_judge_metadata(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source", 1261, "Amjad Ali Bohio")
+        assert all(r.judge_id == 1261 for r in records)
+        assert all(r.judge_name == "Amjad Ali Bohio" for r in records)
+
+    def test_source_url(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source", 1261, "Amjad Ali Bohio")
+        assert all(r.source_url == "test_source" for r in records)
+
+    def test_empty_list(self):
+        records = parse_css_rows([], "test", 1261, "Test Judge")
+        assert records == []
+
+    def test_missing_fields(self):
+        rows = [{"serial": "1", "case_number": "Test 123/2024"}]
+        records = parse_css_rows(rows, "test", 1261, "Test Judge")
+        assert len(records) == 1
+        assert records[0].pdf_url == ""
+        assert records[0].citation == ""
+        assert records[0].case_type == ""
+
+
+class TestParseJudgeRows:
+    """Tests for judges report table parsing."""
+
+    @pytest.fixture
+    def sample_judge_rows(self):
+        return [
+            {
+                "serial": "1",
+                "judge_name": "Hon'ble Mr. Justice Zafar Ahmed Rajput",
+                "total_url": "public/reported-judgements-detail-all/844/-1",
+                "total": "3,672",
+                "afr_url": "public/reported-judgements-detail-all/844/AFR/AFR",
+                "afr": "119",
+            },
+            {
+                "serial": "2",
+                "judge_name": "Hon'ble Mr. Justice Muhammad Iqbal Kalhoro",
+                "total_url": "public/reported-judgements-detail-all/883/-1",
+                "total": "5,929",
+                "afr_url": "public/reported-judgements-detail-all/883/AFR/AFR",
+                "afr": "658",
+            },
+            {
+                "serial": "3",
+                "judge_name": "Hon'ble Mr. Justice Adnan-ul-Karim Memon",
+                "total_url": "public/reported-judgements-detail-all/1061/-1",
+                "total": "8,107",
+                "afr_url": "public/reported-judgements-detail-all/1061/AFR/AFR",
+                "afr": "3,854",
+            },
+        ]
+
+    def test_parses_judges(self, sample_judge_rows):
+        judges = parse_judge_rows(sample_judge_rows)
+        assert len(judges) == 3
+
+    def test_judge_id_extracted(self, sample_judge_rows):
+        judges = parse_judge_rows(sample_judge_rows)
+        assert judges[0]["judge_id"] == 844
+        assert judges[1]["judge_id"] == 883
+        assert judges[2]["judge_id"] == 1061
+
+    def test_judge_name(self, sample_judge_rows):
+        judges = parse_judge_rows(sample_judge_rows)
+        assert "Zafar Ahmed Rajput" in judges[0]["judge_name"]
+
+    def test_total_count(self, sample_judge_rows):
+        judges = parse_judge_rows(sample_judge_rows)
+        assert judges[0]["total"] == 3672
+        assert judges[2]["total"] == 8107
+
+    def test_afr_count(self, sample_judge_rows):
+        judges = parse_judge_rows(sample_judge_rows)
+        assert judges[0]["afr"] == 119
+        assert judges[2]["afr"] == 3854
+
+    def test_empty_list(self):
+        judges = parse_judge_rows([])
+        assert judges == []
+
+    def test_invalid_url_skipped(self):
+        rows = [
+            {
+                "serial": "1",
+                "judge_name": "Test Judge",
+                "total_url": "invalid-url",
+                "total": "100",
+                "afr_url": "",
+                "afr": "50",
+            },
+        ]
+        judges = parse_judge_rows(rows)
+        assert judges == []
+
+    def test_missing_total_url(self):
+        rows = [
+            {
+                "serial": "1",
+                "judge_name": "Test Judge",
+                "total_url": "",
+                "total": "100",
+                "afr_url": "",
+                "afr": "50",
+            },
+        ]
+        judges = parse_judge_rows(rows)
+        assert judges == []
+
+
+class TestJudgmentRecordModel:
+    """Tests for Pydantic model validation."""
+
+    def test_minimal_valid_record(self):
+        record = JudgmentRecord(
+            serial=1,
+            citation="Nil",
+            case_number="C.P. 100/2024",
+            case_type="Constitutional",
+            case_year="2024",
+            parties="A v. B",
+            order_date="15-MAY-24",
+            afr="Yes",
+            head_notes="",
+            bench="Justice X",
+            apex_court="",
+            apex_status="",
+            pdf_url="",
+            judge_id=1061,
+            judge_name="Test Judge",
+            source_url="https://example.com",
+        )
+        assert record.case_number == "C.P. 100/2024"
+        assert record.order_date_parsed is None  # Not auto-parsed by model
+
+    def test_model_dump(self):
+        record = JudgmentRecord(
+            serial=1,
+            citation="2024 SHC KHI 500",
+            case_number="C.P. 100/2024",
+            case_type="Constitutional",
+            case_year="2024",
+            parties="A v. B",
+            order_date="15-MAY-24",
+            order_date_parsed=date(2024, 5, 15),
+            afr="Yes",
+            head_notes="Test note",
+            bench="Justice X",
+            apex_court="",
+            apex_status="",
+            pdf_url="https://example.com/file.pdf",
+            judge_id=1061,
+            judge_name="Test Judge",
+            source_url="https://example.com",
+        )
+        dumped = record.model_dump()
+        assert isinstance(dumped, dict)
+        assert dumped["citation"] == "2024 SHC KHI 500"
+        assert dumped["order_date_parsed"] == date(2024, 5, 15)


### PR DESCRIPTION
## Summary
- crawl4ai pipeline for Sindh HC via caselaw.shc.gov.pk
- Per-judge DataTable extraction with JsonCssExtractionStrategy
- ~65K total judgments across 33 judges, PDFs via download-file.php with base64 doc IDs
- 39 offline tests

## Data Quality (verified live)
| Metric | Coverage |
|--------|----------|
| Records (single judge) | 179 |
| PDF URL | 100% |
| Date parsing | 100% |
| PDF text extraction | 5/5 verified (6K-36K chars) |

## Test plan
- [x] 39 offline unit tests pass
- [x] Live crawl verified: 179 records, 100% coverage
- [x] PDF download + text extraction verified

Closes #3