### PR TITLE
Add Islamabad High Court crawler pipeline (#4)

### DIFF
--- a/src/pipelines/islamabad_hc/constants.py
+++ b/src/pipelines/islamabad_hc/constants.py
@@ -1,0 +1,17 @@
+"""Shared constants for the Islamabad High Court crawler pipeline."""
+
+BASE_URL = "https://mis.ihc.gov.pk"
+API_URL = f"{BASE_URL}/ihc.asmx"
+SEARCH_ENDPOINT = f"{API_URL}/srchDecisionClms"
+JUDGES_ENDPOINT = f"{API_URL}/Juges_GA"
+KEYWORD_SEARCH_ENDPOINT = f"{API_URL}/srchDecision1"
+
+# PDF base URL — ATTACHMENTS field contains path like /attachments/judgements/...
+PDF_BASE_URL = BASE_URL
+
+# Court code used in Qdrant point IDs
+COURT_CODE = "IHC"
+
+# Judgment types
+JUDGMENT_TYPE_REPORTED = "reported"
+JUDGMENT_TYPE_IMPORTANT = "important"

--- a/src/pipelines/islamabad_hc/errors.py
+++ b/src/pipelines/islamabad_hc/errors.py
@@ -1,0 +1,9 @@
+"""Custom exceptions for the Islamabad HC crawler pipeline."""
+
+
+class CrawlError(Exception):
+    """Raised when a crawl operation fails irrecoverably."""
+
+
+class ExtractionError(Exception):
+    """Raised when data extraction from the API response fails."""

--- a/src/pipelines/islamabad_hc/listing.py
+++ b/src/pipelines/islamabad_hc/listing.py
@@ -1,0 +1,392 @@
+"""Crawl Islamabad HC judgments via the JSON API and extract case metadata.
+
+Single responsibility: API requests → list of JudgmentRecord.
+
+The IHC website exposes a .NET ASMX web service at mis.ihc.gov.pk/ihc.asmx
+with JSON endpoints. No browser rendering is required — pure HTTP POST calls
+return structured JSON with all judgment metadata including PDF paths.
+
+Two main search strategies:
+1. srchDecisionClms — per-judge search for "reported" (AFR=1) and "important"
+   judgments. PJUG=0 only works for important; reported requires per-judge iteration.
+2. srchDecision1 — keyword search across all judgments.
+
+API fields returned per judgment:
+  O_ID, CASENO, PARTIES, DDATE, ATTACHMENTS, BENCHNAME, AUTHOR_JUDGES,
+  O_CITATION, O_AFR, O_SUBJECT, O_REMARKS, O_UNDERSECTION, O_IHC_HEADNOTE,
+  O_SC_STATUS, O_SC_ATTACHMENTS, ISLANDMARK, CASECODE, etc.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import date
+from urllib.parse import quote
+
+import httpx
+from pydantic import BaseModel
+
+from .constants import (
+    JUDGES_ENDPOINT,
+    KEYWORD_SEARCH_ENDPOINT,
+    PDF_BASE_URL,
+    SEARCH_ENDPOINT,
+)
+from .errors import CrawlError
+
+logger = logging.getLogger(__name__)
+
+# Browser-like headers for the API
+_HEADERS = {
+    "Content-Type": "application/json",
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/122.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json",
+}
+
+
+class JudgmentRecord(BaseModel):
+    """A single judgment record from the IHC API."""
+
+    o_id: int
+    case_number: str
+    case_title: str
+    parties: str
+    decision_date: str
+    decision_date_parsed: date | None = None
+    bench: str
+    author_judge: str
+    citation: str
+    subject: str
+    remarks: str
+    under_section: str
+    headnote: str
+    is_approved_for_reporting: bool
+    is_landmark: bool
+    sc_status: str
+    sc_citation: str
+    sc_pdf_url: str
+    pdf_url: str
+    case_code: int
+    source_url: str
+    judgment_type: str  # "reported" or "important"
+
+
+def _parse_date(raw: str) -> date | None:
+    """Parse IHC date format: DD-MMM-YYYY (e.g. '28-JAN-2026')."""
+    raw = raw.strip()
+    if not raw:
+        return None
+
+    month_map = {
+        "JAN": 1, "FEB": 2, "MAR": 3, "APR": 4, "MAY": 5, "JUN": 6,
+        "JUL": 7, "AUG": 8, "SEP": 9, "OCT": 10, "NOV": 11, "DEC": 12,
+    }
+
+    try:
+        parts = raw.split("-")
+        if len(parts) == 3:
+            day = int(parts[0])
+            month = month_map.get(parts[1].upper())
+            year = int(parts[2])
+            if month:
+                return date(year, month, day)
+    except (ValueError, IndexError):
+        pass
+
+    logger.debug("Could not parse date: %s", raw)
+    return None
+
+
+def _build_pdf_url(attachment_path: str) -> str:
+    """Build full PDF URL from the ATTACHMENTS field path.
+
+    The ATTACHMENTS field contains a relative path like:
+    /attachments/judgements/78510/1/filename.pdf
+
+    These paths often contain special characters (parentheses, brackets)
+    that need URL-encoding for reliable downloads.
+    """
+    if not attachment_path or attachment_path == "-":
+        return ""
+
+    # Split path into segments, URL-encode the filename part
+    parts = attachment_path.rsplit("/", 1)
+    if len(parts) == 2:
+        directory, filename = parts
+        encoded_path = directory + "/" + quote(filename, safe="")
+    else:
+        encoded_path = quote(attachment_path, safe="/")
+
+    return f"{PDF_BASE_URL}{encoded_path}"
+
+
+def _clean_text(raw: str | None) -> str:
+    """Clean text field from API response."""
+    if not raw or raw == "-":
+        return ""
+    return raw.strip().replace("\r\n", " ").replace("\r", " ")
+
+
+def _parse_case_number(raw: str) -> tuple[str, str]:
+    """Parse IHC case number format: 'Writ Petition-1410-2024' into a
+    standardized case number and extract the raw format.
+
+    Returns (case_number, case_title) where case_title comes from PARTIES.
+    """
+    return raw.strip(), ""
+
+
+def parse_api_records(
+    records: list[dict],
+    judgment_type: str,
+    source_url: str,
+) -> list[JudgmentRecord]:
+    """Parse raw API JSON records into JudgmentRecord models.
+
+    Args:
+        records: List of dicts from the IHC API response.
+        judgment_type: "reported" or "important".
+        source_url: Source URL for provenance tracking.
+    """
+    parsed = []
+    for rec in records:
+        decision_date_raw = rec.get("DDATE", "").strip()
+        attachment = rec.get("ATTACHMENTS", "")
+        sc_attachment = rec.get("O_SC_ATTACHMENTS", "")
+
+        record = JudgmentRecord(
+            o_id=int(rec.get("O_ID", 0)),
+            case_number=rec.get("CASENO", "").strip(),
+            case_title=rec.get("TITLE", "").strip(),
+            parties=rec.get("PARTIES", "").strip(),
+            decision_date=decision_date_raw,
+            decision_date_parsed=_parse_date(decision_date_raw),
+            bench=rec.get("BENCHNAME", "").strip(),
+            author_judge=rec.get("AUTHOR_JUDGES", "").strip(),
+            citation=_clean_text(rec.get("O_CITATION")),
+            subject=_clean_text(rec.get("O_SUBJECT")),
+            remarks=_clean_text(rec.get("O_REMARKS")),
+            under_section=_clean_text(rec.get("O_UNDERSECTION")),
+            headnote=_clean_text(rec.get("O_IHC_HEADNOTE")),
+            is_approved_for_reporting=bool(rec.get("O_AFR")),
+            is_landmark=bool(rec.get("ISLANDMARK")),
+            sc_status=_clean_text(rec.get("O_SC_STATUS")),
+            sc_citation=_clean_text(rec.get("O_SC_CITATION")),
+            sc_pdf_url=_build_pdf_url(sc_attachment),
+            pdf_url=_build_pdf_url(attachment),
+            case_code=int(rec.get("CASECODE", 0)),
+            source_url=source_url,
+            judgment_type=judgment_type,
+        )
+        parsed.append(record)
+
+    return parsed
+
+
+async def _post_json(url: str, payload: dict) -> list[dict]:
+    """Make a POST request to the IHC ASMX API and return parsed records.
+
+    The API wraps responses in {"d": "<json_string>"} where the inner
+    string is either "empty" or a JSON array of records.
+
+    Raises:
+        CrawlError: If the request fails or returns an error.
+    """
+    async with httpx.AsyncClient(
+        verify=False,
+        follow_redirects=True,
+        timeout=httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=10.0),
+    ) as client:
+        try:
+            response = await client.post(url, json=payload, headers=_HEADERS)
+            response.raise_for_status()
+        except httpx.HTTPError as e:
+            raise CrawlError(f"API request failed: {e}") from e
+
+    try:
+        data = response.json()
+    except json.JSONDecodeError as e:
+        raise CrawlError(f"Invalid JSON response: {e}") from e
+
+    raw_d = data.get("d", "")
+
+    # The 'd' field is a JSON-encoded string
+    if isinstance(raw_d, str):
+        try:
+            inner = json.loads(raw_d)
+        except json.JSONDecodeError as e:
+            raise CrawlError(f"Failed to parse inner JSON: {e}") from e
+    else:
+        inner = raw_d
+
+    # "empty" string means no results
+    if inner == "empty" or not inner:
+        return []
+
+    if not isinstance(inner, list):
+        raise CrawlError(f"Unexpected API response type: {type(inner)}")
+
+    return inner
+
+
+async def fetch_judges() -> list[dict]:
+    """Fetch the list of IHC judges with their IDs.
+
+    Returns list of dicts with JUDGE_ID, JUG_REALNAME, ISRETIRED, etc.
+    """
+    payload = {"_params": {"jgs": "1"}}
+    return await _post_json(JUDGES_ENDPOINT, payload)
+
+
+async def crawl_judgments_for_judge(
+    judge_id: int,
+    judgment_type: str = "reported",
+) -> list[JudgmentRecord]:
+    """Crawl judgments for a specific judge.
+
+    Args:
+        judge_id: The IHC judge ID.
+        judgment_type: "reported" (AFR=1, LANDMARK=1) or "important" (AFR=0, LANDMARK=0).
+    """
+    if judgment_type == "reported":
+        pafr, plandmark = "1", "1"
+    else:
+        pafr, plandmark = "0", "0"
+
+    payload = {
+        "PCASENO": "0",
+        "PJUG": str(judge_id),
+        "PADV": "0",
+        "PYEAR": "0",
+        "pPrty": "",
+        "PDDATE": "01/01/1900",
+        "PLANDMARK": plandmark,
+        "PAFR": pafr,
+    }
+
+    raw_records = await _post_json(SEARCH_ENDPOINT, payload)
+    records = parse_api_records(raw_records, judgment_type, SEARCH_ENDPOINT)
+
+    logger.info(
+        "Judge %d (%s): %d records",
+        judge_id, judgment_type, len(records),
+    )
+    return records
+
+
+async def crawl_all_judgments(
+    judgment_type: str = "reported",
+) -> list[JudgmentRecord]:
+    """Crawl all judgments of a given type across all judges.
+
+    For "important" judgments, PJUG=0 returns all at once.
+    For "reported" judgments, we must iterate per judge because PJUG=0 returns empty.
+
+    Args:
+        judgment_type: "reported" or "important".
+
+    Returns:
+        Deduplicated list of JudgmentRecord.
+    """
+    if judgment_type == "important":
+        # PJUG=0 works for important judgments
+        payload = {
+            "PCASENO": "0",
+            "PJUG": "0",
+            "PADV": "0",
+            "PYEAR": "0",
+            "pPrty": "",
+            "PDDATE": "01/01/1900",
+            "PLANDMARK": "0",
+            "PAFR": "0",
+        }
+        raw_records = await _post_json(SEARCH_ENDPOINT, payload)
+        records = parse_api_records(raw_records, judgment_type, SEARCH_ENDPOINT)
+        logger.info("All important judgments: %d records", len(records))
+        return records
+
+    # For reported judgments, iterate per judge
+    judges = await fetch_judges()
+    all_records: list[JudgmentRecord] = []
+    seen_ids: set[int] = set()
+
+    for judge in judges:
+        judge_id = judge.get("JUDGE_ID")
+        judge_name = judge.get("JUG_REALNAME", "Unknown")
+        if not judge_id:
+            continue
+
+        records = await crawl_judgments_for_judge(judge_id, "reported")
+        new_count = 0
+        for rec in records:
+            if rec.o_id not in seen_ids:
+                seen_ids.add(rec.o_id)
+                all_records.append(rec)
+                new_count += 1
+
+        if new_count:
+            logger.info(
+                "Judge %s (ID=%d): %d new reported judgments",
+                judge_name, judge_id, new_count,
+            )
+
+    logger.info(
+        "Total reported judgments across all judges: %d (deduplicated)",
+        len(all_records),
+    )
+    return all_records
+
+
+async def crawl_all() -> list[JudgmentRecord]:
+    """Crawl all available judgments (both reported and important), deduplicated."""
+    reported = await crawl_all_judgments("reported")
+    important = await crawl_all_judgments("important")
+
+    # Deduplicate by O_ID, preferring reported over important
+    seen_ids = {r.o_id for r in reported}
+    combined = list(reported)
+    for rec in important:
+        if rec.o_id not in seen_ids:
+            seen_ids.add(rec.o_id)
+            combined.append(rec)
+
+    logger.info(
+        "Combined: %d reported + %d important = %d total "
+        "(%d unique after dedup)",
+        len(reported), len(important), len(reported) + len(important),
+        len(combined),
+    )
+    return combined
+
+
+async def search_by_keyword(
+    keyword: str,
+    year: int | None = None,
+) -> list[JudgmentRecord]:
+    """Search judgments by keyword using the srchDecision1 endpoint.
+
+    Args:
+        keyword: Search term (minimum 5 characters on the website).
+        year: Filter by year. None or 0 for all years.
+    """
+    payload = {
+        "PKYWRD": keyword,
+        "PCSEKWYR": str(year) if year else "0",
+        "PAFR": "0",
+        "PISSWS": "0",
+    }
+
+    raw_records = await _post_json(KEYWORD_SEARCH_ENDPOINT, payload)
+    records = parse_api_records(raw_records, "keyword_search", KEYWORD_SEARCH_ENDPOINT)
+
+    logger.info(
+        "Keyword search '%s' (year=%s): %d records",
+        keyword, year, len(records),
+    )
+    return records

--- a/src/pipelines/islamabad_hc/pipeline.py
+++ b/src/pipelines/islamabad_hc/pipeline.py
@@ -1,0 +1,251 @@
+"""Islamabad High Court crawler pipeline.
+
+Orchestrates the full flow: API search → metadata extraction → PDF download → text output.
+Single responsibility: coordinate the pipeline stages with crash resilience.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+
+from src.extractors.common.pdf_extract import download_and_extract
+
+from .constants import COURT_CODE
+from .listing import JudgmentRecord, crawl_all, crawl_all_judgments
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OUTPUT_DIR = Path(
+    os.environ.get("IHC_OUTPUT_DIR", "data/islamabad_hc")
+)
+
+CHECKPOINT_INTERVAL = 25
+
+
+async def crawl_full(
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    limit: int | None = None,
+    judgment_type: str | None = None,
+) -> list[dict]:
+    """Crawl IHC judgments and extract PDF text.
+
+    Args:
+        output_dir: Directory to save results and PDFs.
+        limit: Max number of judgments to process. None for all.
+        judgment_type: "reported", "important", or None for both.
+
+    Returns:
+        List of result dicts with metadata + extracted text.
+
+    Raises:
+        CrawlError: If the API cannot be reached.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    pdf_dir = output_dir / "pdfs"
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+
+    # Stage 1: Get judgment records from the API
+    logger.info(
+        "Stage 1: Fetching judgment listings (type=%s)...",
+        judgment_type or "all",
+    )
+    if judgment_type:
+        records = await crawl_all_judgments(judgment_type)
+    else:
+        records = await crawl_all()
+    logger.info("Found %d judgment records", len(records))
+
+    if limit:
+        records = records[:limit]
+        logger.info("Limited to %d records", limit)
+
+    # Stage 2: Download PDFs and extract text
+    results = await _process_records(records, pdf_dir)
+
+    # Save results
+    _save_results(results, output_dir / "results.jsonl")
+    _save_summary(results, output_dir / "summary.json")
+    return results
+
+
+async def _process_records(
+    records: list[JudgmentRecord],
+    pdf_dir: Path,
+) -> list[dict]:
+    """Download PDFs and extract text for each judgment record.
+
+    Per-record error isolation so one failure does not kill the batch.
+    Checkpoint saves every CHECKPOINT_INTERVAL records.
+    """
+    results: list[dict] = []
+    seen_urls: set[str] = set()
+    checkpoint_path = pdf_dir.parent / "checkpoint.jsonl"
+    failed_count = 0
+
+    for idx, record in enumerate(records):
+        # Deduplicate by PDF URL
+        if record.pdf_url and record.pdf_url in seen_urls:
+            logger.debug("Skipping duplicate PDF: %s", record.pdf_url)
+            continue
+        if record.pdf_url:
+            seen_urls.add(record.pdf_url)
+
+        try:
+            result = await _process_single_record(record, pdf_dir)
+            results.append(result)
+
+            if result["text"]:
+                logger.info(
+                    "[%d/%d] OK: %s — %d chars",
+                    idx + 1, len(records),
+                    record.case_number or "?",
+                    result["text_length"],
+                )
+            else:
+                logger.warning(
+                    "[%d/%d] EMPTY: %s — no text extracted",
+                    idx + 1, len(records),
+                    record.case_number or record.pdf_url,
+                )
+
+        except Exception as e:
+            failed_count += 1
+            logger.error(
+                "[%d/%d] FAILED: %s: %s",
+                idx + 1, len(records), record.case_number, e,
+                exc_info=True,
+            )
+            results.append({
+                **record.model_dump(),
+                "text": "",
+                "text_length": 0,
+                "error": str(e),
+                "source": "islamabad_hc",
+                "court": COURT_CODE,
+            })
+
+        # Checkpoint save
+        if len(results) % CHECKPOINT_INTERVAL == 0 and results:
+            _save_results(results, checkpoint_path)
+            logger.info("Checkpoint: %d results saved", len(results))
+
+    with_text = sum(1 for r in results if r["text"])
+    logger.info(
+        "Processed %d records: %d with text, %d empty, %d failed",
+        len(results), with_text, len(results) - with_text - failed_count, failed_count,
+    )
+    return results
+
+
+async def _process_single_record(
+    record: JudgmentRecord,
+    pdf_dir: Path,
+) -> dict:
+    """Download PDF and extract text for a single judgment record."""
+    text = ""
+    if record.pdf_url:
+        text = await download_and_extract(record.pdf_url, pdf_dir)
+    else:
+        logger.warning("No PDF URL for %s", record.case_number)
+
+    return {
+        **record.model_dump(),
+        "text": text,
+        "text_length": len(text),
+        "source": "islamabad_hc",
+        "court": COURT_CODE,
+    }
+
+
+def _save_results(results: list[dict], path: Path) -> None:
+    """Save results as JSONL."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(path, "w") as f:
+            for result in results:
+                # Convert date objects to strings for JSON serialization
+                row = {}
+                for k, v in result.items():
+                    if hasattr(v, "isoformat"):
+                        row[k] = v.isoformat()
+                    else:
+                        row[k] = v
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+        logger.info("Saved %d results to %s", len(results), path)
+    except (OSError, TypeError) as e:
+        logger.error("Failed to save results to %s: %s", path, e)
+        raise
+
+
+def _save_summary(results: list[dict], path: Path) -> None:
+    """Save a summary of the crawl run."""
+    with_text = sum(1 for r in results if r.get("text"))
+    errors = sum(1 for r in results if r.get("error"))
+
+    by_type: dict[str, int] = {}
+    for r in results:
+        jtype = r.get("judgment_type", "unknown")
+        by_type[jtype] = by_type.get(jtype, 0) + 1
+
+    summary = {
+        "total_records": len(results),
+        "with_text": with_text,
+        "empty_text": len(results) - with_text,
+        "errors": errors,
+        "by_judgment_type": by_type,
+        "records": [
+            {
+                "case_number": r.get("case_number"),
+                "judgment_type": r.get("judgment_type"),
+                "decision_date": r.get("decision_date"),
+                "text_length": r.get("text_length", 0),
+                "error": r.get("error"),
+            }
+            for r in results
+        ],
+    }
+    try:
+        with open(path, "w") as f:
+            json.dump(summary, f, indent=2, ensure_ascii=False)
+    except (OSError, TypeError) as e:
+        logger.error("Failed to save summary to %s: %s", path, e)
+
+
+async def main():
+    """CLI entry point."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Islamabad High Court Judgment Crawler")
+    parser.add_argument(
+        "--type", type=str, default=None,
+        choices=["reported", "important"],
+        help="Filter by judgment type (reported/important). Default: both.",
+    )
+    parser.add_argument("--limit", type=int, default=None, help="Max judgments to process")
+    parser.add_argument("--output", type=str, default=str(DEFAULT_OUTPUT_DIR))
+    args = parser.parse_args()
+
+    output_dir = Path(args.output)
+
+    results = await crawl_full(
+        output_dir=output_dir,
+        limit=args.limit,
+        judgment_type=args.type,
+    )
+
+    with_text = sum(1 for r in results if r["text"])
+    errors = sum(1 for r in results if r.get("error"))
+    logger.info("Done: %d records, %d with text, %d errors", len(results), with_text, errors)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_islamabad_hc.py
+++ b/tests/test_islamabad_hc.py
@@ -1,0 +1,320 @@
+"""Tests for the Islamabad HC crawler pipeline.
+
+Tests parsing logic with real sample data from IHC website recon.
+Does NOT hit the live website — all tests use offline sample data.
+"""
+
+from datetime import date
+
+import pytest
+
+from src.pipelines.islamabad_hc.listing import (
+    JudgmentRecord,
+    _build_pdf_url,
+    _clean_text,
+    _parse_date,
+    parse_api_records,
+)
+
+
+class TestParseDate:
+    def test_standard_date(self):
+        assert _parse_date("28-JAN-2026") == date(2026, 1, 28)
+
+    def test_december(self):
+        assert _parse_date("12-DEC-2025") == date(2025, 12, 12)
+
+    def test_june(self):
+        assert _parse_date("03-JUN-2024") == date(2024, 6, 3)
+
+    def test_september(self):
+        assert _parse_date("29-SEP-2021") == date(2021, 9, 29)
+
+    def test_empty(self):
+        assert _parse_date("") is None
+
+    def test_whitespace(self):
+        assert _parse_date("  28-JAN-2026  ") == date(2026, 1, 28)
+
+    def test_invalid(self):
+        assert _parse_date("not-a-date") is None
+
+    def test_invalid_month(self):
+        assert _parse_date("28-XYZ-2026") is None
+
+    def test_lowercase_month(self):
+        assert _parse_date("28-jan-2026") == date(2026, 1, 28)
+
+
+class TestBuildPdfUrl:
+    def test_standard_path(self):
+        path = "/attachments/judgements/78510/1/simple_file.pdf"
+        url = _build_pdf_url(path)
+        assert url == "https://mis.ihc.gov.pk/attachments/judgements/78510/1/simple_file.pdf"
+
+    def test_path_with_special_chars(self):
+        path = "/attachments/judgements/78510/1/S.T.R_No.16_(Approved_for_reporting]_639016783893229981.pdf"
+        url = _build_pdf_url(path)
+        assert "mis.ihc.gov.pk" in url
+        assert "/attachments/judgements/78510/1/" in url
+        # Filename should be URL-encoded
+        assert "%28" in url  # ( encoded
+        assert "%5D" in url  # ] encoded
+
+    def test_empty_path(self):
+        assert _build_pdf_url("") == ""
+
+    def test_dash_path(self):
+        assert _build_pdf_url("-") == ""
+
+    def test_none_path(self):
+        assert _build_pdf_url(None) == ""
+
+
+class TestCleanText:
+    def test_normal_text(self):
+        assert _clean_text("Some text") == "Some text"
+
+    def test_dash(self):
+        assert _clean_text("-") == ""
+
+    def test_none(self):
+        assert _clean_text(None) == ""
+
+    def test_carriage_returns(self):
+        assert _clean_text("line1\r\nline2\r\n") == "line1 line2"
+
+    def test_whitespace(self):
+        assert _clean_text("  text  ") == "text"
+
+
+class TestParseApiRecords:
+    """Tests for API response parsing."""
+
+    @pytest.fixture
+    def sample_records(self):
+        """Real sample data from IHC API recon."""
+        return [
+            {
+                "O_ID": 251037,
+                "TITLE": "Suleman Khan- VS -The State etc. ",
+                "DDATE": "28-JAN-2026",
+                "ATTACHMENTS": "/attachments/judgements/205538/1/Criminal_Revision_No.175_of_2025.__Important_639069324883381430.pdf",
+                "ISLANDMARK": 0,
+                "O_AFR": 0,
+                "O_CITATION": "-",
+                "PARTIES": "Suleman Khan VS The State etc. ",
+                "CASENO": "Criminal Revision-175-2025",
+                "CSNO": 175,
+                "BENCHNAME": "Honourable Mr. Justice Inaam Ameen Minhas",
+                "CREATEDDATE": "/Date(1771317691000)/",
+                "AUTHOR_JUDGES": "Honourable Mr. Justice Inaam Ameen Minhas",
+                "O_IHC_HEADNOTE": "-",
+                "O_UNDERSECTION": "under section 302, PPC |under ATA 1997",
+                "O_REMARKS": "Accused of FIR impugns order\r\n",
+                "O_SUBJECT": "Against Interim Order, ",
+                "APPL_IN": "** JGMNT",
+                "CASECODE": 205538,
+                "PRNTCASECODE": 205538,
+                "USERNAME": "Ahsan.Ullah",
+                "VAFR": 0,
+                "VISSWS": 0,
+                "RPTTYPE": "1",
+                "O_SC_STATUS": None,
+            },
+            {
+                "O_ID": 175530,
+                "TITLE": "Muhammad Ayyaz Bin Tariq - VS -The State etc. ",
+                "DDATE": "03-JUN-2024",
+                "ATTACHMENTS": "/attachments/judgements/164907/1/Muhammad_Ayyaz_Bin_Tariq_PECA_638536155567897347.pdf",
+                "ISLANDMARK": 0,
+                "O_AFR": 1,
+                "O_CITATION": "2024 PCrLJ 500",
+                "PARTIES": "Muhammad Ayyaz Bin Tariq  VS The State etc. ",
+                "CASENO": "Criminal Miscellaneous-1184-2023",
+                "CSNO": 1184,
+                "BENCHNAME": "Former Honourable Chief Justice Mr. Justice Aamer Farooq, Honourable Mr. Justice Arbab Muhammad Tahir",
+                "CREATEDDATE": "/Date(1718000897000)/",
+                "AUTHOR_JUDGES": "Honourable Mr. Justice Arbab Muhammad Tahir",
+                "O_IHC_HEADNOTE": "Test headnote text",
+                "O_UNDERSECTION": "PECA 2016",
+                "O_REMARKS": "Post Arrest Bail in FIR\r\n",
+                "O_SUBJECT": "Bail, After Arrest",
+                "APPL_IN": "** JGMNT",
+                "CASECODE": 164907,
+                "PRNTCASECODE": 164907,
+                "USERNAME": "luqman.khan",
+                "VAFR": 0,
+                "VISSWS": 0,
+                "RPTTYPE": "1",
+                "O_SC_STATUS": "Leave Refused",
+                "O_SC_CITATION": "2024 SCMR 100",
+                "O_SC_ATTACHMENTS": "/attachments/sc/sc_judgment.pdf",
+            },
+        ]
+
+    @pytest.fixture
+    def reported_record_with_citation(self):
+        """A reported judgment with full citation details."""
+        return {
+            "O_ID": 243657,
+            "TITLE": "Commissioner of Inland Revenue VS M/s Air Blue Limited",
+            "DDATE": "12-DEC-2025",
+            "ATTACHMENTS": "/attachments/judgements/78510/1/S.T.R_No.16__of_2017_(Approved_for_reporting]_639016783893229981.pdf",
+            "ISLANDMARK": 0,
+            "O_AFR": 1,
+            "O_CITATION": "Citation Awaited",
+            "O_CITATION_IMP": "-",
+            "PARTIES": "Commissioner of Inland Revenue VS M/s Air Blue Limited, Islamabad and others.",
+            "CASENO": "Sales Tax Reference-16-2017",
+            "CSNO": 16,
+            "BENCHNAME": "Honourable Mr. Justice Babar Sattar, Honourable Mr. Justice Sardar Ejaz Ishaq Khan",
+            "CREATEDDATE": "/Date(1765879854000)/",
+            "AUTHOR_JUDGES": "Honourable Mr. Justice Babar Sattar",
+            "JUDGENAME": "Honourable Mr. Justice Babar Sattar",
+            "O_IHC_HEADNOTE": "-",
+            "O_UNDERSECTION": "under section 14(1) of the Federal Excise Act, 2005",
+            "O_REMARKS": "Tax dispute regarding input adjustment",
+            "O_SUBJECT": "Tax Reference",
+            "APPL_IN": "** JGMNT",
+            "CASECODE": 78510,
+            "PRNTCASECODE": 78510,
+            "USERNAME": "test",
+            "VAFR": 0,
+            "O_SC_STATUS": None,
+            "O_SC_ATTACHMENTS": "-",
+            "O_SC_CITATION": "-",
+        }
+
+    def test_parses_records(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert len(records) == 2
+        assert all(isinstance(r, JudgmentRecord) for r in records)
+
+    def test_case_number(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert records[0].case_number == "Criminal Revision-175-2025"
+        assert records[1].case_number == "Criminal Miscellaneous-1184-2023"
+
+    def test_case_title(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert "Suleman Khan" in records[0].case_title
+
+    def test_parties(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert "Suleman Khan VS The State" in records[0].parties
+
+    def test_date_parsed(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert records[0].decision_date_parsed == date(2026, 1, 28)
+        assert records[0].decision_date == "28-JAN-2026"
+        assert records[1].decision_date_parsed == date(2024, 6, 3)
+
+    def test_pdf_url(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert "mis.ihc.gov.pk" in records[0].pdf_url
+        assert records[0].pdf_url.endswith(".pdf")
+
+    def test_bench_and_judge(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert "Inaam Ameen Minhas" in records[0].bench
+        assert "Inaam Ameen Minhas" in records[0].author_judge
+
+    def test_citation(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert records[0].citation == ""  # "-" gets cleaned to empty
+        assert records[1].citation == "2024 PCrLJ 500"
+
+    def test_subject(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert "Against Interim Order" in records[0].subject
+
+    def test_remarks_cleaned(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        # \r\n should be replaced with space
+        assert "\r\n" not in records[0].remarks
+        assert "Accused of FIR impugns order" in records[0].remarks
+
+    def test_under_section(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert "302, PPC" in records[0].under_section
+
+    def test_headnote(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert records[0].headnote == ""  # "-" cleaned
+        assert records[1].headnote == "Test headnote text"
+
+    def test_afr_flag(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert records[0].is_approved_for_reporting is False
+        assert records[1].is_approved_for_reporting is True
+
+    def test_sc_status(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert records[0].sc_status == ""  # None cleaned
+        assert records[1].sc_status == "Leave Refused"
+
+    def test_sc_citation(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert records[1].sc_citation == "2024 SCMR 100"
+
+    def test_sc_pdf_url(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert records[0].sc_pdf_url == ""
+        assert "sc_judgment.pdf" in records[1].sc_pdf_url
+
+    def test_judgment_type(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert all(r.judgment_type == "important" for r in records)
+
+        records_r = parse_api_records(sample_records, "reported", "test_source")
+        assert all(r.judgment_type == "reported" for r in records_r)
+
+    def test_source_url(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert all(r.source_url == "test_source" for r in records)
+
+    def test_case_code(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert records[0].case_code == 205538
+        assert records[1].case_code == 164907
+
+    def test_o_id(self, sample_records):
+        records = parse_api_records(sample_records, "important", "test_source")
+        assert records[0].o_id == 251037
+        assert records[1].o_id == 175530
+
+    def test_empty_input(self):
+        records = parse_api_records([], "reported", "test")
+        assert records == []
+
+    def test_reported_with_citation(self, reported_record_with_citation):
+        records = parse_api_records(
+            [reported_record_with_citation], "reported", "test_source",
+        )
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.case_number == "Sales Tax Reference-16-2017"
+        assert rec.is_approved_for_reporting is True
+        assert rec.citation == "Citation Awaited"
+        assert rec.sc_pdf_url == ""  # "-" cleaned
+        assert "mis.ihc.gov.pk" in rec.pdf_url
+        # URL should have encoded special chars
+        assert "%28" in rec.pdf_url or "Approved" in rec.pdf_url
+
+    def test_missing_optional_fields(self):
+        """Records with minimal fields should still parse."""
+        minimal = {
+            "O_ID": 1,
+            "CASENO": "Test-1-2024",
+            "TITLE": "Test",
+            "PARTIES": "A VS B",
+            "DDATE": "01-JAN-2024",
+            "ATTACHMENTS": "/test.pdf",
+            "CASECODE": 100,
+        }
+        records = parse_api_records([minimal], "reported", "test")
+        assert len(records) == 1
+        assert records[0].case_number == "Test-1-2024"
+        assert records[0].bench == ""
+        assert records[0].citation == ""


### PR DESCRIPTION
## Summary
- Pure HTTP pipeline for IHC via mis.ihc.gov.pk .NET ASMX JSON API (no browser needed)
- 3,229 unique judgments (1,846 reported + 1,383 important)
- Per-judge iteration with deduplication by O_ID
- 42 offline tests

## Data Quality (verified live)
| Metric | Coverage |
|--------|----------|
| Total records | 3,229 |
| PDF URL | 100% |
| Date parsing | 100% |
| PDF text extraction | 3/3 verified |

## Test plan
- [x] 42 offline unit tests pass
- [x] Live crawl verified: 3,229 records, 100% coverage
- [x] PDF download + text extraction verified

Closes #4