### PR TITLE
Add Balochistan High Court crawler pipeline (#6)

### DIFF
--- a/src/pipelines/balochistan_hc/constants.py
+++ b/src/pipelines/balochistan_hc/constants.py
@@ -1,0 +1,40 @@
+"""Shared constants for the Balochistan High Court crawler pipeline."""
+
+import os
+
+# The main BHC website is behind Incapsula WAF.
+# The portal subdomain hosts a Nuxt.js SPA with a proxied JSON API.
+BASE_URL = os.environ.get("BHC_BASE_URL", "https://bhc.gov.pk")
+PORTAL_URL = os.environ.get("BHC_PORTAL_URL", "https://portal.bhc.gov.pk")
+JUDGMENTS_URL = f"{PORTAL_URL}/judgments"
+
+# The Nuxt app proxies API requests to this backend.
+# We use the portal URL for API calls (through the browser session)
+# because the backend (api.bhc.gov.pk) requires authentication tokens
+# that only the Nuxt server-side proxy provides.
+API_JUDGMENTS_PATH = "/v2/judgments"
+API_DOWNLOAD_PATH = "/v2/downloadpdf"
+API_COURTS_PATH = "/v2/courts"
+API_JUDGES_PATH = "/v2/judges"
+API_CATEGORIES_PATH = "/v2/categories"
+
+# Search mode constants (searchBy parameter)
+SEARCH_BY_CASE_ID = 1
+SEARCH_BY_COURT = 2
+SEARCH_BY_JUDGE = 3
+
+# Court type constants from the BHC portal
+COURT_TYPE_SUPREME = 10
+COURT_TYPE_HIGH_COURT = 20
+COURT_TYPE_HC_BENCH = 21  # Principal Seat Quetta, Sibi Bench, etc.
+COURT_TYPE_SESSIONS = 30
+COURT_TYPE_TRIBUNAL = 31  # Services Tribunal, Customs Tribunal
+
+# The highCourtBenches getter in the portal filters for types 21 and 31
+HC_BENCH_TYPES = {COURT_TYPE_HC_BENCH, COURT_TYPE_TRIBUNAL}
+
+# Court code used in Qdrant point IDs
+COURT_CODE = "BHC"
+
+# Years available in the portal (from JS: for loop 2001 to current year)
+YEARS = list(range(2001, 2027))

--- a/src/pipelines/balochistan_hc/errors.py
+++ b/src/pipelines/balochistan_hc/errors.py
@@ -1,0 +1,9 @@
+"""Custom exceptions for the Balochistan HC crawler pipeline."""
+
+
+class CrawlError(Exception):
+    """Raised when a crawl operation fails irrecoverably."""
+
+
+class ExtractionError(Exception):
+    """Raised when data extraction from the portal API fails."""

--- a/src/pipelines/balochistan_hc/listing.py
+++ b/src/pipelines/balochistan_hc/listing.py
@@ -1,0 +1,464 @@
+"""Crawl Balochistan HC judgments via the portal.bhc.gov.pk JSON API.
+
+Single responsibility: browser session bootstrap + API query -> list of JudgmentRecord.
+
+The BHC portal (portal.bhc.gov.pk) is a Nuxt.js SPA that proxies API requests
+to api.bhc.gov.pk. The main bhc.gov.pk domain is protected by Incapsula WAF,
+which crawl4ai bypasses using stealth mode.
+
+Strategy:
+1. Open the judgments page with crawl4ai (stealth mode bypasses Incapsula WAF).
+2. Wait for the Nuxt/Vue app to initialize and Vuex store to hydrate.
+3. Dispatch Vuex actions to load reference data (courts, judges, categories).
+4. Call the /v2/judgments API through the Nuxt $axios proxy.
+5. Extract results from a hidden DOM element injected by our JS code.
+
+The API supports three search modes:
+- searchBy=1: Search by case ID
+- searchBy=2: Search by court + category + date range
+- searchBy=3: Search by judge + date range
+
+API response fields per record:
+  FILE_ID, FILE_FOLDER, FILE_NAME, FILE_EXT (for PDF download URL)
+  CASE_ID, CASE_TITLE, REGISTER_NUMBER
+  AUTHOR_JUDGE, TYPE_NAME, ORDER_DATE (dd/mm/yyyy)
+"""
+
+from __future__ import annotations
+
+import html
+import json
+import logging
+import re
+from datetime import date
+
+from pydantic import BaseModel
+
+from .constants import API_JUDGMENTS_PATH, JUDGMENTS_URL, PORTAL_URL
+from .errors import CrawlError
+
+logger = logging.getLogger(__name__)
+
+
+class JudgmentRecord(BaseModel):
+    """A single judgment record from the BHC portal API."""
+
+    file_id: int
+    case_id: int
+    case_number: str
+    case_title: str
+    author_judge: str
+    type_name: str
+    order_date: str
+    order_date_parsed: date | None = None
+    pdf_url: str
+    source_url: str
+
+
+class CrawlResult(BaseModel):
+    """Result of a judgment crawl including auth info for PDF downloads."""
+
+    records: list[JudgmentRecord]
+    auth_token: str = ""
+    api_base_url: str = ""
+
+
+def _parse_date(raw: str) -> date | None:
+    """Parse dd/mm/yyyy date string from the BHC API."""
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        parts = raw.split("/")
+        if len(parts) == 3:
+            return date(int(parts[2]), int(parts[1]), int(parts[0]))
+    except (ValueError, IndexError):
+        pass
+    logger.debug("Could not parse date: %s", raw)
+    return None
+
+
+def _clean_html_entities(text: str) -> str:
+    """Decode HTML entities like &nbsp; in case titles."""
+    return html.unescape(text).strip()
+
+
+API_BASE_URL = "https://api.bhc.gov.pk"
+
+
+def _build_pdf_url(record: dict) -> str:
+    """Build the PDF download URL from API response fields.
+
+    URL pattern: {API_BASE_URL}/v2/downloadpdf/{FILE_FOLDER}/{FILE_NAME}.{FILE_EXT}
+
+    The download function in the portal uses FILE_FOLDER (year), not FILE_ID.
+    Downloads require a Bearer token from the authenticated browser session.
+    Despite .doc/.docx extensions, the API returns PDF content.
+    """
+    file_folder = record.get("FILE_FOLDER", "")
+    file_name = record.get("FILE_NAME", "")
+    file_ext = record.get("FILE_EXT", "")
+    if not file_folder or not file_name:
+        return ""
+    return f"{API_BASE_URL}/v2/downloadpdf/{file_folder}/{file_name}.{file_ext}"
+
+
+def parse_api_response(
+    raw_records: list[dict],
+    source_url: str,
+) -> list[JudgmentRecord]:
+    """Parse raw API response records into JudgmentRecord models.
+
+    Args:
+        raw_records: List of dicts from the /v2/judgments API response.
+        source_url: Source URL for provenance tracking.
+    """
+    records = []
+    for raw in raw_records:
+        order_date_raw = raw.get("ORDER_DATE", "").strip()
+        case_title = _clean_html_entities(raw.get("CASE_TITLE", ""))
+
+        record = JudgmentRecord(
+            file_id=int(raw.get("FILE_ID", 0) or 0),
+            case_id=int(raw.get("CASE_ID", 0) or 0),
+            case_number=raw.get("REGISTER_NUMBER", "").strip(),
+            case_title=case_title,
+            author_judge=raw.get("AUTHOR_JUDGE", "").strip(),
+            type_name=raw.get("TYPE_NAME", "").strip(),
+            order_date=order_date_raw,
+            order_date_parsed=_parse_date(order_date_raw),
+            pdf_url=_build_pdf_url(raw),
+            source_url=source_url,
+        )
+        records.append(record)
+
+    return records
+
+
+def _build_search_js(
+    search_by: int,
+    judge_id: int | None = None,
+    court_id: int | None = None,
+    category_id: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> str:
+    """Build JavaScript to search via Nuxt $axios and dump results to DOM.
+
+    The JS code:
+    1. Waits for the Nuxt app and Vuex store to be ready.
+    2. Dispatches actions to load reference data (courts, judges).
+    3. Calls /v2/judgments via the Nuxt $axios proxy.
+    4. Writes JSON results into a hidden DOM element for extraction.
+    """
+    # Default date range: 2001-01-01 to today + 1 day
+    if not start_date:
+        start_date = "2001-01-01"
+    if not end_date:
+        end_date = "2026-12-31"
+
+    form_obj = {
+        "searchBy": search_by,
+        "sDate": start_date,
+        "eDate": end_date,
+    }
+    if judge_id is not None:
+        form_obj["judgeId"] = judge_id
+    if court_id is not None:
+        form_obj["courtId"] = court_id
+    if category_id is not None:
+        form_obj["categoryId"] = category_id
+
+    form_json = json.dumps(form_obj)
+
+    return f"""
+    (async () => {{
+        // Wait for Nuxt/Vue to be ready
+        for (let i = 0; i < 40; i++) {{
+            if (window.$nuxt && window.$nuxt.$store) break;
+            await new Promise(r => setTimeout(r, 500));
+        }}
+
+        const resultDiv = document.createElement('div');
+        resultDiv.id = 'bhc-api-result';
+        resultDiv.style.display = 'none';
+
+        if (!window.$nuxt || !window.$nuxt.$store) {{
+            resultDiv.textContent = JSON.stringify({{error: 'Nuxt store not available'}});
+            document.body.appendChild(resultDiv);
+            return;
+        }}
+
+        const axios = window.$nuxt.$axios;
+        const authToken = (axios.defaults.headers.common || {{}}).Authorization || '';
+        const apiBaseUrl = axios.defaults.baseURL || '';
+
+        try {{
+            const result = await axios.$post(
+                '/v2/judgments',
+                {form_json}
+            );
+            resultDiv.textContent = JSON.stringify({{
+                success: true,
+                count: result.length,
+                records: result,
+                auth_token: authToken,
+                api_base_url: apiBaseUrl,
+            }});
+        }} catch(e) {{
+            resultDiv.textContent = JSON.stringify({{
+                error: e.message || 'API call failed',
+                status: e.response ? e.response.status : null,
+            }});
+        }}
+        document.body.appendChild(resultDiv);
+    }})();
+    """
+
+
+def _build_load_metadata_js() -> str:
+    """Build JavaScript to load reference data (courts, judges, categories)."""
+    return """
+    (async () => {
+        for (let i = 0; i < 40; i++) {
+            if (window.$nuxt && window.$nuxt.$store) break;
+            await new Promise(r => setTimeout(r, 500));
+        }
+
+        const resultDiv = document.createElement('div');
+        resultDiv.id = 'bhc-api-result';
+        resultDiv.style.display = 'none';
+
+        if (!window.$nuxt || !window.$nuxt.$store) {
+            resultDiv.textContent = JSON.stringify({error: 'Nuxt store not available'});
+            document.body.appendChild(resultDiv);
+            return;
+        }
+
+        const store = window.$nuxt.$store;
+        try {
+            await store.dispatch('repository/LOAD_COURTS');
+        } catch(e) {}
+        try {
+            await store.dispatch('repository/LOAD_JUDGES');
+        } catch(e) {}
+        await new Promise(r => setTimeout(r, 1000));
+
+        const state = store.state.repository;
+        const courts = state.courts || [];
+        const judges = state.judges || [];
+
+        resultDiv.textContent = JSON.stringify({
+            success: true,
+            courts: courts.filter(c => {
+                const t = parseInt(c.COURT_TYPE, 10);
+                return t === 21 || t === 31;
+            }),
+            judges: judges.filter(j => parseInt(j.TOTAL_ORDERS, 10) > 0),
+            categories: state.categories || [],
+        });
+        document.body.appendChild(resultDiv);
+    })();
+    """
+
+
+def _extract_api_result(html_content: str) -> dict:
+    """Extract the API result JSON from the hidden DOM element."""
+    match = re.search(r'id="bhc-api-result"[^>]*>([^<]+)', html_content)
+    if not match:
+        raise CrawlError("Could not find API result element in page HTML")
+    try:
+        return json.loads(match.group(1))
+    except json.JSONDecodeError as e:
+        raise CrawlError(f"Failed to parse API result JSON: {e}") from e
+
+
+async def load_metadata() -> dict:
+    """Load reference data (courts, judges, categories) from the BHC portal.
+
+    Returns:
+        Dict with 'courts', 'judges', and 'categories' lists.
+
+    Raises:
+        CrawlError: If the portal cannot be accessed or data loading fails.
+    """
+    from crawl4ai import (
+        AsyncWebCrawler,
+        BrowserConfig,
+        CacheMode,
+        CrawlerRunConfig,
+    )
+
+    browser_config = BrowserConfig(
+        headless=True,
+        enable_stealth=True,
+        extra_args=["--ignore-certificate-errors"],
+    )
+
+    run_config = CrawlerRunConfig(
+        cache_mode=CacheMode.BYPASS,
+        wait_until="networkidle",
+        delay_before_return_html=12.0,
+        page_timeout=90000,
+        magic=True,
+        js_code=_build_load_metadata_js(),
+    )
+
+    async with AsyncWebCrawler(config=browser_config) as crawler:
+        result = await crawler.arun(url=JUDGMENTS_URL, config=run_config)
+        if not result.success:
+            raise CrawlError(f"Failed to load portal: {result.error_message}")
+
+        data = _extract_api_result(result.html)
+        if "error" in data:
+            raise CrawlError(f"Metadata load failed: {data['error']}")
+
+        logger.info(
+            "Loaded metadata: %d courts, %d judges, %d categories",
+            len(data.get("courts", [])),
+            len(data.get("judges", [])),
+            len(data.get("categories", [])),
+        )
+        return data
+
+
+async def crawl_judgments_by_judge(
+    judge_id: int,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> CrawlResult:
+    """Crawl BHC judgments for a specific judge.
+
+    Args:
+        judge_id: Judge ID from the BHC portal.
+        start_date: Start date in yyyy-mm-dd format. Defaults to 2001-01-01.
+        end_date: End date in yyyy-mm-dd format. Defaults to 2026-12-31.
+
+    Returns:
+        CrawlResult with records and auth info for PDF downloads.
+
+    Raises:
+        CrawlError: If the API call fails.
+    """
+    from crawl4ai import (
+        AsyncWebCrawler,
+        BrowserConfig,
+        CacheMode,
+        CrawlerRunConfig,
+    )
+
+    browser_config = BrowserConfig(
+        headless=True,
+        enable_stealth=True,
+        extra_args=["--ignore-certificate-errors"],
+    )
+
+    js_code = _build_search_js(
+        search_by=3,
+        judge_id=judge_id,
+        start_date=start_date,
+        end_date=end_date,
+    )
+
+    run_config = CrawlerRunConfig(
+        cache_mode=CacheMode.BYPASS,
+        wait_until="networkidle",
+        delay_before_return_html=15.0,
+        page_timeout=90000,
+        magic=True,
+        js_code=js_code,
+    )
+
+    async with AsyncWebCrawler(config=browser_config) as crawler:
+        result = await crawler.arun(url=JUDGMENTS_URL, config=run_config)
+        if not result.success:
+            raise CrawlError(f"Crawl failed: {result.error_message}")
+
+        data = _extract_api_result(result.html)
+        if "error" in data:
+            raise CrawlError(f"API error: {data['error']}")
+
+        raw_records = data.get("records", [])
+        records = parse_api_response(raw_records, JUDGMENTS_URL)
+
+        logger.info(
+            "Crawled %d judgment records for judge_id=%d",
+            len(records), judge_id,
+        )
+        return CrawlResult(
+            records=records,
+            auth_token=data.get("auth_token", ""),
+            api_base_url=data.get("api_base_url", ""),
+        )
+
+
+async def crawl_all_judges() -> CrawlResult:
+    """Crawl all BHC judgments by iterating through all judges.
+
+    This is the most reliable approach because the API returns all results
+    for a given judge without pagination limits.
+
+    Returns:
+        CrawlResult with deduplicated records and auth info.
+
+    Raises:
+        CrawlError: If metadata loading fails.
+    """
+    metadata = await load_metadata()
+    judges = metadata.get("judges", [])
+
+    if not judges:
+        raise CrawlError("No judges found in metadata")
+
+    logger.info("Crawling judgments for %d judges...", len(judges))
+
+    all_records: list[JudgmentRecord] = []
+    seen_file_ids: set[int] = set()
+    auth_token = ""
+    api_base_url = ""
+
+    for idx, judge in enumerate(judges):
+        judge_id = judge["JUDGE_ID"]
+        judge_name = judge["JUDGE_NAME"]
+        total_orders = judge.get("TOTAL_ORDERS", 0)
+
+        logger.info(
+            "[%d/%d] Judge: %s (ID=%d, expected=%d orders)",
+            idx + 1, len(judges), judge_name, judge_id, total_orders,
+        )
+
+        try:
+            crawl_result = await crawl_judgments_by_judge(judge_id)
+
+            # Keep the latest auth token (refreshed each browser session)
+            if crawl_result.auth_token:
+                auth_token = crawl_result.auth_token
+                api_base_url = crawl_result.api_base_url
+
+            # Deduplicate by file_id
+            new_count = 0
+            for record in crawl_result.records:
+                if record.file_id not in seen_file_ids:
+                    seen_file_ids.add(record.file_id)
+                    all_records.append(record)
+                    new_count += 1
+
+            logger.info(
+                "  -> %d records (%d new, %d duplicates)",
+                len(crawl_result.records), new_count,
+                len(crawl_result.records) - new_count,
+            )
+        except CrawlError as e:
+            logger.error(
+                "  -> FAILED: %s (continuing with next judge)", e,
+            )
+
+    logger.info(
+        "Total: %d unique judgment records from %d judges",
+        len(all_records), len(judges),
+    )
+    return CrawlResult(
+        records=all_records,
+        auth_token=auth_token,
+        api_base_url=api_base_url,
+    )

--- a/src/pipelines/balochistan_hc/pipeline.py
+++ b/src/pipelines/balochistan_hc/pipeline.py
@@ -1,0 +1,373 @@
+"""Balochistan High Court crawler pipeline.
+
+Orchestrates the full flow: API search -> record extraction -> PDF download -> text output.
+Single responsibility: coordinate the pipeline stages with crash resilience.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+
+from src.extractors.common.pdf_extract import download_and_extract
+
+from .constants import COURT_CODE
+from .listing import CrawlResult, JudgmentRecord, crawl_judgments_by_judge, load_metadata
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OUTPUT_DIR = Path(
+    os.environ.get("BHC_OUTPUT_DIR", "data/balochistan_hc")
+)
+
+CHECKPOINT_INTERVAL = 25
+
+
+async def crawl_full(
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    limit: int | None = None,
+    judge_id: int | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> list[dict]:
+    """Crawl BHC judgments and extract PDF text.
+
+    Args:
+        output_dir: Directory to save results and PDFs.
+        limit: Max number of judgments to process. None for all.
+        judge_id: Filter by specific judge ID. None for all judges.
+        start_date: Start date in yyyy-mm-dd format.
+        end_date: End date in yyyy-mm-dd format.
+
+    Returns:
+        List of result dicts with metadata + extracted text.
+
+    Raises:
+        CrawlError: If the portal cannot be accessed.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    pdf_dir = output_dir / "pdfs"
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+
+    # Stage 1: Get judgment records
+    if judge_id is not None:
+        logger.info(
+            "Stage 1: Crawling judgments for judge_id=%d...", judge_id,
+        )
+        crawl_result = await crawl_judgments_by_judge(
+            judge_id, start_date=start_date, end_date=end_date,
+        )
+    else:
+        logger.info("Stage 1: Crawling judgments for all judges...")
+        crawl_result = await _crawl_all_judges_with_dedup(
+            start_date=start_date, end_date=end_date,
+        )
+
+    records = crawl_result.records
+    logger.info("Found %d judgment records", len(records))
+
+    if limit:
+        records = records[:limit]
+        logger.info("Limited to %d records", limit)
+
+    # Build auth headers for PDF downloads from the BHC API
+    pdf_headers = None
+    if crawl_result.auth_token:
+        pdf_headers = {
+            "Authorization": crawl_result.auth_token,
+            "Accept": "*/*",
+        }
+        logger.info("Using authenticated PDF downloads via api.bhc.gov.pk")
+
+    # Stage 2: Download PDFs and extract text
+    results = await _process_records(records, pdf_dir, pdf_headers=pdf_headers)
+
+    # Save results
+    _save_results(results, output_dir / "results.jsonl")
+    _save_summary(results, output_dir / "summary.json")
+    return results
+
+
+async def _crawl_all_judges_with_dedup(
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> CrawlResult:
+    """Crawl all judges and deduplicate results."""
+    metadata = await load_metadata()
+    judges = metadata.get("judges", [])
+
+    if not judges:
+        logger.warning("No judges found in metadata")
+        return CrawlResult(records=[])
+
+    logger.info("Crawling judgments for %d judges...", len(judges))
+
+    all_records: list[JudgmentRecord] = []
+    seen_file_ids: set[int] = set()
+    auth_token = ""
+    api_base_url = ""
+
+    for idx, judge in enumerate(judges):
+        jid = judge["JUDGE_ID"]
+        judge_name = judge["JUDGE_NAME"]
+
+        logger.info(
+            "[%d/%d] Judge: %s (ID=%d)",
+            idx + 1, len(judges), judge_name, jid,
+        )
+
+        try:
+            crawl_result = await crawl_judgments_by_judge(
+                jid, start_date=start_date, end_date=end_date,
+            )
+
+            if crawl_result.auth_token:
+                auth_token = crawl_result.auth_token
+                api_base_url = crawl_result.api_base_url
+
+            new_count = 0
+            for record in crawl_result.records:
+                if record.file_id not in seen_file_ids:
+                    seen_file_ids.add(record.file_id)
+                    all_records.append(record)
+                    new_count += 1
+
+            logger.info(
+                "  -> %d records (%d new)",
+                len(crawl_result.records), new_count,
+            )
+        except Exception as e:
+            logger.error("  -> FAILED: %s", e)
+
+    logger.info("Total: %d unique records", len(all_records))
+    return CrawlResult(
+        records=all_records,
+        auth_token=auth_token,
+        api_base_url=api_base_url,
+    )
+
+
+async def crawl_judge(
+    judge_id: int,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    limit: int | None = None,
+) -> list[dict]:
+    """Crawl judgments for a single BHC judge."""
+    return await crawl_full(
+        output_dir=output_dir, limit=limit, judge_id=judge_id,
+    )
+
+
+async def _process_records(
+    records: list[JudgmentRecord],
+    pdf_dir: Path,
+    pdf_headers: dict | None = None,
+) -> list[dict]:
+    """Download PDFs and extract text for each judgment record.
+
+    Per-record error isolation so one failure does not kill the batch.
+    Checkpoint saves every CHECKPOINT_INTERVAL records.
+    """
+    results: list[dict] = []
+    seen_urls: set[str] = set()
+    checkpoint_path = pdf_dir.parent / "checkpoint.jsonl"
+    failed_count = 0
+
+    for idx, record in enumerate(records):
+        # Deduplicate by PDF URL
+        if record.pdf_url and record.pdf_url in seen_urls:
+            logger.debug("Skipping duplicate PDF: %s", record.pdf_url)
+            continue
+        if record.pdf_url:
+            seen_urls.add(record.pdf_url)
+
+        try:
+            result = await _process_single_record(record, pdf_dir, pdf_headers)
+            results.append(result)
+
+            if result["text"]:
+                logger.info(
+                    "[%d/%d] OK: %s - %d chars",
+                    idx + 1, len(records),
+                    record.case_number or "?",
+                    result["text_length"],
+                )
+            else:
+                logger.warning(
+                    "[%d/%d] EMPTY: %s - no text extracted",
+                    idx + 1, len(records),
+                    record.case_number or record.pdf_url,
+                )
+
+        except Exception as e:
+            failed_count += 1
+            logger.error(
+                "[%d/%d] FAILED: %s: %s",
+                idx + 1, len(records), record.case_number, e,
+                exc_info=True,
+            )
+            results.append({
+                **record.model_dump(),
+                "text": "",
+                "text_length": 0,
+                "error": str(e),
+                "source": "balochistan_hc",
+                "court": COURT_CODE,
+            })
+
+        # Checkpoint save
+        if len(results) % CHECKPOINT_INTERVAL == 0 and results:
+            _save_results(results, checkpoint_path)
+            logger.info("Checkpoint: %d results saved", len(results))
+
+    with_text = sum(1 for r in results if r["text"])
+    logger.info(
+        "Processed %d records: %d with text, %d empty, %d failed",
+        len(results), with_text,
+        len(results) - with_text - failed_count, failed_count,
+    )
+    return results
+
+
+async def _process_single_record(
+    record: JudgmentRecord,
+    pdf_dir: Path,
+    pdf_headers: dict | None = None,
+) -> dict:
+    """Download PDF and extract text for a single judgment record.
+
+    The BHC API requires a Bearer token for PDF downloads. The pdf_headers
+    dict contains the Authorization header from the authenticated browser session.
+    """
+    text = ""
+    if record.pdf_url:
+        text = await download_and_extract(
+            record.pdf_url, pdf_dir, headers=pdf_headers,
+        )
+    else:
+        logger.warning("No PDF URL for %s", record.case_number)
+
+    return {
+        **record.model_dump(),
+        "text": text,
+        "text_length": len(text),
+        "source": "balochistan_hc",
+        "court": COURT_CODE,
+    }
+
+
+def _save_results(results: list[dict], path: Path) -> None:
+    """Save results as JSONL."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(path, "w") as f:
+            for result in results:
+                row = {}
+                for k, v in result.items():
+                    if hasattr(v, "isoformat"):
+                        row[k] = v.isoformat()
+                    else:
+                        row[k] = v
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+        logger.info("Saved %d results to %s", len(results), path)
+    except (OSError, TypeError) as e:
+        logger.error("Failed to save results to %s: %s", path, e)
+        raise
+
+
+def _save_summary(results: list[dict], path: Path) -> None:
+    """Save a summary of the crawl run."""
+    with_text = sum(1 for r in results if r.get("text"))
+    errors = sum(1 for r in results if r.get("error"))
+
+    by_type: dict[str, int] = {}
+    for r in results:
+        t = r.get("type_name", "unknown")
+        by_type[t] = by_type.get(t, 0) + 1
+
+    by_judge: dict[str, int] = {}
+    for r in results:
+        j = r.get("author_judge", "unknown")
+        by_judge[j] = by_judge.get(j, 0) + 1
+
+    summary = {
+        "total_records": len(results),
+        "with_text": with_text,
+        "empty_text": len(results) - with_text,
+        "errors": errors,
+        "by_type": by_type,
+        "by_judge": by_judge,
+        "records": [
+            {
+                "case_number": r.get("case_number"),
+                "type_name": r.get("type_name"),
+                "order_date": r.get("order_date"),
+                "text_length": r.get("text_length", 0),
+                "error": r.get("error"),
+            }
+            for r in results
+        ],
+    }
+    try:
+        with open(path, "w") as f:
+            json.dump(summary, f, indent=2, ensure_ascii=False)
+    except (OSError, TypeError) as e:
+        logger.error("Failed to save summary to %s: %s", path, e)
+
+
+async def main() -> None:
+    """CLI entry point."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Balochistan High Court Judgment Crawler",
+    )
+    parser.add_argument(
+        "--judge-id", type=int, default=None,
+        help="Filter by judge ID",
+    )
+    parser.add_argument(
+        "--start-date", type=str, default=None,
+        help="Start date (yyyy-mm-dd)",
+    )
+    parser.add_argument(
+        "--end-date", type=str, default=None,
+        help="End date (yyyy-mm-dd)",
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None,
+        help="Max judgments to process",
+    )
+    parser.add_argument(
+        "--output", type=str, default=str(DEFAULT_OUTPUT_DIR),
+    )
+    args = parser.parse_args()
+
+    output_dir = Path(args.output)
+
+    results = await crawl_full(
+        output_dir=output_dir,
+        limit=args.limit,
+        judge_id=args.judge_id,
+        start_date=args.start_date,
+        end_date=args.end_date,
+    )
+
+    with_text = sum(1 for r in results if r["text"])
+    errors = sum(1 for r in results if r.get("error"))
+    logger.info(
+        "Done: %d records, %d with text, %d errors",
+        len(results), with_text, errors,
+    )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_balochistan_hc.py
+++ b/tests/test_balochistan_hc.py
@@ -1,0 +1,341 @@
+"""Tests for the Balochistan HC crawler pipeline.
+
+All tests use offline sample data — no live website hits.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from src.pipelines.balochistan_hc.constants import (
+    COURT_CODE,
+    COURT_TYPE_HC_BENCH,
+    COURT_TYPE_TRIBUNAL,
+    HC_BENCH_TYPES,
+    PORTAL_URL,
+    SEARCH_BY_CASE_ID,
+    SEARCH_BY_COURT,
+    SEARCH_BY_JUDGE,
+)
+from src.pipelines.balochistan_hc.listing import (
+    API_BASE_URL,
+    CrawlResult,
+    JudgmentRecord,
+    _build_pdf_url,
+    _build_search_js,
+    _clean_html_entities,
+    _extract_api_result,
+    _parse_date,
+    parse_api_response,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_API_RECORD = {
+    "FILE_ID": 225535,
+    "FILE_FOLDER": "2025",
+    "FILE_NAME": "100107804897_97bcbd69f9b646b0add9c77386812f65",
+    "FILE_EXT": "doc",
+    "CASE_ID": 100107804897,
+    "CASE_TITLE": "Muhammad Younas S/O Noor Muhammad vs Chief Election Commissoner And&nbsp;Another",
+    "REGISTER_NUMBER": "CP-2191/2025",
+    "AUTHOR_JUDGE": "Hon'ble Chief Justice Muhammad Kamran Khan Malakhail",
+    "TYPE_NAME": "Short Order",
+    "ORDER_DATE": "24/12/2025",
+}
+
+SAMPLE_API_RECORD_NO_PDF = {
+    "FILE_ID": 0,
+    "FILE_FOLDER": "",  # Empty folder means no PDF URL
+    "FILE_NAME": "",
+    "FILE_EXT": "",
+    "CASE_ID": 999,
+    "CASE_TITLE": "Test Case",
+    "REGISTER_NUMBER": "CP-1/2024",
+    "AUTHOR_JUDGE": "Judge X",
+    "TYPE_NAME": "Judgment",
+    "ORDER_DATE": "",
+}
+
+SAMPLE_API_RECORD_MINIMAL = {
+    "FILE_ID": 12345,
+    "FILE_FOLDER": "2023",
+    "FILE_NAME": "test_file_abc123",
+    "FILE_EXT": "pdf",
+    "CASE_ID": 456,
+    "CASE_TITLE": "Simple vs Case",
+    "REGISTER_NUMBER": "WP-100/2023",
+    "AUTHOR_JUDGE": "",
+    "TYPE_NAME": "",
+    "ORDER_DATE": "01/01/2023",
+}
+
+SAMPLE_HTML_WITH_RESULT = '''
+<html><body>
+<div id="bhc-api-result" style="display:none">{"success":true,"count":2,"records":[
+{"FILE_ID":100,"FILE_FOLDER":"2024","FILE_NAME":"test1","FILE_EXT":"pdf",
+"CASE_ID":1,"CASE_TITLE":"A vs B","REGISTER_NUMBER":"CP-1/2024",
+"AUTHOR_JUDGE":"Judge A","TYPE_NAME":"Judgment","ORDER_DATE":"15/06/2024"},
+{"FILE_ID":101,"FILE_FOLDER":"2024","FILE_NAME":"test2","FILE_EXT":"doc",
+"CASE_ID":2,"CASE_TITLE":"C vs D&amp;nbsp;E","REGISTER_NUMBER":"WP-2/2024",
+"AUTHOR_JUDGE":"Judge B","TYPE_NAME":"Short Order","ORDER_DATE":"20/07/2024"}
+],"auth_token":"Bearer test123","api_base_url":"https://api.bhc.gov.pk/"}</div>
+</body></html>
+'''
+
+
+# ---------------------------------------------------------------------------
+# Tests: _parse_date
+# ---------------------------------------------------------------------------
+
+class TestParseDate:
+    def test_valid_date(self) -> None:
+        assert _parse_date("24/12/2025") == date(2025, 12, 24)
+
+    def test_first_of_year(self) -> None:
+        assert _parse_date("01/01/2023") == date(2023, 1, 1)
+
+    def test_empty_string(self) -> None:
+        assert _parse_date("") is None
+
+    def test_whitespace(self) -> None:
+        assert _parse_date("  ") is None
+
+    def test_invalid_format(self) -> None:
+        assert _parse_date("2025-12-24") is None
+
+    def test_invalid_date(self) -> None:
+        assert _parse_date("32/13/2025") is None
+
+    def test_partial_date(self) -> None:
+        assert _parse_date("24/12") is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: _clean_html_entities
+# ---------------------------------------------------------------------------
+
+class TestCleanHtmlEntities:
+    def test_nbsp(self) -> None:
+        assert _clean_html_entities("A&nbsp;B") == "A\u00a0B"
+
+    def test_amp(self) -> None:
+        assert _clean_html_entities("A&amp;B") == "A&B"
+
+    def test_no_entities(self) -> None:
+        assert _clean_html_entities("plain text") == "plain text"
+
+    def test_whitespace_trim(self) -> None:
+        assert _clean_html_entities("  hello  ") == "hello"
+
+    def test_empty(self) -> None:
+        assert _clean_html_entities("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_pdf_url
+# ---------------------------------------------------------------------------
+
+class TestBuildPdfUrl:
+    def test_valid_record(self) -> None:
+        url = _build_pdf_url(SAMPLE_API_RECORD)
+        expected = (
+            f"{API_BASE_URL}/v2/downloadpdf/2025/"
+            "100107804897_97bcbd69f9b646b0add9c77386812f65.doc"
+        )
+        assert url == expected
+
+    def test_no_file_folder(self) -> None:
+        assert _build_pdf_url({"FILE_FOLDER": "", "FILE_NAME": "x", "FILE_EXT": "pdf"}) == ""
+
+    def test_no_file_name(self) -> None:
+        assert _build_pdf_url({"FILE_FOLDER": "2024", "FILE_NAME": "", "FILE_EXT": "pdf"}) == ""
+
+    def test_missing_fields(self) -> None:
+        assert _build_pdf_url({}) == ""
+
+
+# ---------------------------------------------------------------------------
+# Tests: parse_api_response
+# ---------------------------------------------------------------------------
+
+class TestParseApiResponse:
+    def test_single_record(self) -> None:
+        records = parse_api_response([SAMPLE_API_RECORD], "https://test.url")
+        assert len(records) == 1
+        r = records[0]
+        assert r.file_id == 225535
+        assert r.case_id == 100107804897
+        assert r.case_number == "CP-2191/2025"
+        assert "Muhammad Younas" in r.case_title
+        assert "\u00a0" in r.case_title  # &nbsp; decoded
+        assert r.order_date == "24/12/2025"
+        assert r.order_date_parsed == date(2025, 12, 24)
+        assert r.type_name == "Short Order"
+        assert "downloadpdf/2025" in r.pdf_url
+        assert r.source_url == "https://test.url"
+
+    def test_empty_list(self) -> None:
+        assert parse_api_response([], "url") == []
+
+    def test_no_pdf_url(self) -> None:
+        records = parse_api_response([SAMPLE_API_RECORD_NO_PDF], "url")
+        assert len(records) == 1
+        assert records[0].pdf_url == ""
+        assert records[0].order_date_parsed is None
+
+    def test_minimal_record(self) -> None:
+        records = parse_api_response([SAMPLE_API_RECORD_MINIMAL], "url")
+        assert len(records) == 1
+        r = records[0]
+        assert r.case_number == "WP-100/2023"
+        assert r.author_judge == ""
+        assert r.order_date_parsed == date(2023, 1, 1)
+
+    def test_multiple_records(self) -> None:
+        records = parse_api_response(
+            [SAMPLE_API_RECORD, SAMPLE_API_RECORD_MINIMAL], "url",
+        )
+        assert len(records) == 2
+        assert records[0].case_number == "CP-2191/2025"
+        assert records[1].case_number == "WP-100/2023"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _extract_api_result
+# ---------------------------------------------------------------------------
+
+class TestExtractApiResult:
+    def test_valid_html(self) -> None:
+        data = _extract_api_result(SAMPLE_HTML_WITH_RESULT)
+        assert data["success"] is True
+        assert data["count"] == 2
+        assert len(data["records"]) == 2
+
+    def test_missing_element(self) -> None:
+        from src.pipelines.balochistan_hc.errors import CrawlError
+        with pytest.raises(CrawlError, match="Could not find"):
+            _extract_api_result("<html><body></body></html>")
+
+    def test_invalid_json(self) -> None:
+        from src.pipelines.balochistan_hc.errors import CrawlError
+        html = '<div id="bhc-api-result">not valid json</div>'
+        with pytest.raises(CrawlError, match="Failed to parse"):
+            _extract_api_result(html)
+
+    def test_error_response(self) -> None:
+        html = '<div id="bhc-api-result">{"error":"API call failed"}</div>'
+        data = _extract_api_result(html)
+        assert "error" in data
+
+
+# ---------------------------------------------------------------------------
+# Tests: _build_search_js
+# ---------------------------------------------------------------------------
+
+class TestBuildSearchJs:
+    def test_search_by_judge(self) -> None:
+        js = _build_search_js(search_by=SEARCH_BY_JUDGE, judge_id=1038)
+        assert "/v2/judgments" in js
+        assert '"searchBy": 3' in js
+        assert '"judgeId": 1038' in js
+
+    def test_search_by_court(self) -> None:
+        js = _build_search_js(
+            search_by=SEARCH_BY_COURT, court_id=100, category_id="Bail",
+        )
+        assert '"searchBy": 2' in js
+        assert '"courtId": 100' in js
+        assert '"categoryId": "Bail"' in js
+
+    def test_custom_date_range(self) -> None:
+        js = _build_search_js(
+            search_by=SEARCH_BY_JUDGE,
+            judge_id=1,
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+        )
+        assert "2024-01-01" in js
+        assert "2024-12-31" in js
+
+    def test_default_date_range(self) -> None:
+        js = _build_search_js(search_by=SEARCH_BY_CASE_ID)
+        assert "2001-01-01" in js
+        assert "2026-12-31" in js
+
+
+# ---------------------------------------------------------------------------
+# Tests: JudgmentRecord model
+# ---------------------------------------------------------------------------
+
+class TestJudgmentRecord:
+    def test_serialization(self) -> None:
+        record = JudgmentRecord(
+            file_id=100,
+            case_id=1,
+            case_number="CP-1/2024",
+            case_title="A vs B",
+            author_judge="Judge A",
+            type_name="Judgment",
+            order_date="15/06/2024",
+            order_date_parsed=date(2024, 6, 15),
+            pdf_url="https://portal.bhc.gov.pk/v2/downloadpdf/100/test.pdf",
+            source_url="https://portal.bhc.gov.pk/judgments",
+        )
+        d = record.model_dump()
+        assert d["file_id"] == 100
+        assert d["case_number"] == "CP-1/2024"
+        assert d["order_date_parsed"] == date(2024, 6, 15)
+
+    def test_optional_date(self) -> None:
+        record = JudgmentRecord(
+            file_id=1,
+            case_id=1,
+            case_number="X",
+            case_title="Y",
+            author_judge="Z",
+            type_name="T",
+            order_date="",
+            pdf_url="",
+            source_url="",
+        )
+        assert record.order_date_parsed is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: Constants
+# ---------------------------------------------------------------------------
+
+class TestCrawlResult:
+    def test_with_auth(self) -> None:
+        result = CrawlResult(
+            records=[],
+            auth_token="Bearer abc123",
+            api_base_url="https://api.bhc.gov.pk/",
+        )
+        assert result.auth_token == "Bearer abc123"
+        assert result.api_base_url == "https://api.bhc.gov.pk/"
+
+    def test_defaults(self) -> None:
+        result = CrawlResult(records=[])
+        assert result.auth_token == ""
+        assert result.api_base_url == ""
+
+
+class TestConstants:
+    def test_court_code(self) -> None:
+        assert COURT_CODE == "BHC"
+
+    def test_hc_bench_types(self) -> None:
+        assert COURT_TYPE_HC_BENCH in HC_BENCH_TYPES
+        assert COURT_TYPE_TRIBUNAL in HC_BENCH_TYPES
+
+    def test_search_by_values(self) -> None:
+        assert SEARCH_BY_CASE_ID == 1
+        assert SEARCH_BY_COURT == 2
+        assert SEARCH_BY_JUDGE == 3


### PR DESCRIPTION
## Summary
- crawl4ai stealth mode bypasses Incapsula WAF (no proxies needed)
- Nuxt.js SPA portal backed by REST API at api.bhc.gov.pk
- Auto-authenticates as guest user, Bearer token for API + PDF downloads
- 38 judges, 70 case categories, 8 bench courts
- 36 offline tests

## Data Quality (verified live)
| Metric | Coverage |
|--------|----------|
| Records (single judge, 2025) | 461 |
| PDF URL | 100% |
| Date parsing | 100% |
| Case number | 100% |
| PDF text extraction | 3/3 verified |

## Test plan
- [x] 36 offline unit tests pass
- [x] Live crawl verified: 461 records, 100% coverage
- [x] PDF download with auth token verified

Closes #6