### PR TITLE
Add Supreme Court crawler pipeline (#1)

### DIFF
--- a/src/pipelines/supreme_court/constants.py
+++ b/src/pipelines/supreme_court/constants.py
@@ -1,0 +1,32 @@
+"""Shared constants for the Supreme Court of Pakistan crawler pipeline.
+
+Site structure (from Wayback Machine recon, Aug 2024):
+- WordPress-based site behind Akamai CDN
+- Judgments listed at /category/judgements/ as blog posts
+- Individual judgments at /constitution-petition-no-39-of-2019/ style slugs
+- PDF judgments linked within individual post pages
+- No DataTable / server-side search — WordPress category pagination
+
+As of March 2026, the site is down for maintenance (NADRA).
+This pipeline is built to handle anti-bot measures (Akamai) when it returns.
+"""
+
+BASE_URL = "https://www.supremecourt.gov.pk"
+JUDGMENTS_URL = f"{BASE_URL}/category/judgements/"
+
+# Court code used in Qdrant point IDs
+COURT_CODE = "SC"
+
+# WordPress pagination: /category/judgements/page/N/
+PAGINATION_TEMPLATE = f"{JUDGMENTS_URL}page/{{page}}/"
+
+# Maintenance page detection
+MAINTENANCE_MARKERS = [
+    "Site Under Maintenance",
+    "We'll Be Back Soon",
+    "currently down for maintenance",
+]
+
+# Crawl settings
+REQUEST_DELAY_SECONDS = 2.0
+MAX_PAGES = 200  # Safety limit for pagination

--- a/src/pipelines/supreme_court/errors.py
+++ b/src/pipelines/supreme_court/errors.py
@@ -1,0 +1,13 @@
+"""Custom exceptions for the Supreme Court crawler pipeline."""
+
+
+class CrawlError(Exception):
+    """Raised when a crawl operation fails irrecoverably."""
+
+
+class ExtractionError(Exception):
+    """Raised when data extraction from HTML/PDF fails."""
+
+
+class SiteMaintenanceError(CrawlError):
+    """Raised when the Supreme Court site is down for maintenance."""

--- a/src/pipelines/supreme_court/listing.py
+++ b/src/pipelines/supreme_court/listing.py
@@ -1,0 +1,437 @@
+"""Crawl Supreme Court of Pakistan judgment listings and extract case metadata.
+
+Single responsibility: WordPress category page crawl → list of JudgmentRecord.
+
+The SC website is a WordPress site behind Akamai CDN. Judgments are listed as
+blog posts under /category/judgements/ with standard WordPress pagination.
+
+Uses crawl4ai with anti-bot features:
+- BrowserConfig with enable_stealth for Akamai bypass
+- CrawlerRunConfig with magic=True for enhanced evasion
+- JsonCssExtractionStrategy for structured post extraction
+- Maintenance detection before proceeding
+
+Site was down for maintenance as of March 2026. The pipeline detects the
+maintenance page and raises SiteMaintenanceError instead of silently failing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+from datetime import date
+
+from pydantic import BaseModel
+
+from .constants import (
+    BASE_URL,
+    JUDGMENTS_URL,
+    MAINTENANCE_MARKERS,
+    MAX_PAGES,
+    PAGINATION_TEMPLATE,
+    REQUEST_DELAY_SECONDS,
+)
+from .errors import CrawlError, SiteMaintenanceError
+
+logger = logging.getLogger(__name__)
+
+
+class JudgmentRecord(BaseModel):
+    """A single judgment post extracted from the SC website."""
+
+    title: str
+    case_number: str
+    post_url: str
+    pdf_url: str
+    decision_date: str
+    decision_date_parsed: date | None = None
+    bench: str
+    summary: str
+    source_url: str
+
+
+def _parse_case_number(title: str) -> str:
+    """Extract case number from judgment post title.
+
+    SC titles follow patterns like:
+    - "Constitution Petition No. 39 of 2019"
+    - "Civil Appeal No. 1234 of 2023"
+    - "Criminal Appeal No. 567 of 2022"
+    - "SMC No. 1 of 2024"
+    """
+    title = title.strip()
+    match = re.match(
+        r"^((?:Constitution\s+Petition|Civil\s+Appeal|Criminal\s+Appeal|"
+        r"Cr(?:iminal)?\.?\s*(?:Appeal|Petition|Review)|"
+        r"C(?:ivil)?\.?\s*(?:Appeal|Petition|Review)|"
+        r"SMC|HRC|CPLA|CMA|CRP|"
+        r"(?:Writ|W)\.?\s*P(?:etition)?|"
+        r"(?:Human\s+Rights\s+Case)|"
+        r"(?:Suo\s+Motu\s+Case)|"
+        r"[A-Z][A-Za-z.]+)\s*"
+        r"No\.?\s*\d+[-/]?\w*\s*(?:of|OF)\s*\d{4})",
+        title,
+        re.IGNORECASE,
+    )
+    if match:
+        return match.group(1).strip()
+    return title
+
+
+def _parse_date(raw: str) -> date | None:
+    """Parse date from various formats used on SC website.
+
+    Handles:
+    - "December 23, 2024" (WordPress default)
+    - "23-12-2024" (dd-mm-yyyy)
+    - "2024-12-23" (ISO)
+    """
+    raw = raw.strip()
+    if not raw:
+        return None
+
+    # WordPress format: "Month Day, Year"
+    import calendar
+
+    month_names = {m.lower(): i for i, m in enumerate(calendar.month_name) if m}
+    month_abbrs = {m.lower(): i for i, m in enumerate(calendar.month_abbr) if m}
+
+    # Try "Month Day, Year"
+    match = re.match(r"(\w+)\s+(\d{1,2}),?\s+(\d{4})", raw)
+    if match:
+        month_str, day, year = match.group(1).lower(), int(match.group(2)), int(match.group(3))
+        month = month_names.get(month_str) or month_abbrs.get(month_str)
+        if month:
+            try:
+                return date(year, month, day)
+            except ValueError:
+                pass
+
+    # Try dd-mm-yyyy
+    match = re.match(r"(\d{1,2})-(\d{1,2})-(\d{4})", raw)
+    if match:
+        try:
+            return date(int(match.group(3)), int(match.group(2)), int(match.group(1)))
+        except ValueError:
+            pass
+
+    # Try ISO yyyy-mm-dd
+    match = re.match(r"(\d{4})-(\d{1,2})-(\d{1,2})", raw)
+    if match:
+        try:
+            return date(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+        except ValueError:
+            pass
+
+    logger.debug("Could not parse date: %s", raw)
+    return None
+
+
+def _is_maintenance_page(html: str) -> bool:
+    """Check if the page content indicates site maintenance."""
+    if not html:
+        return False
+    for marker in MAINTENANCE_MARKERS:
+        if marker.lower() in html.lower():
+            return True
+    return False
+
+
+# JsonCssExtractionStrategy schema for WordPress judgment posts.
+# SC uses standard WordPress article markup under /category/judgements/.
+CSS_EXTRACTION_SCHEMA = {
+    "name": "SC Judgments",
+    "baseSelector": "article.post, article.type-post, .post",
+    "fields": [
+        {"name": "title", "selector": "h2 a, h2.entry-title a, .entry-title a", "type": "text"},
+        {
+            "name": "post_url",
+            "selector": "h2 a, h2.entry-title a, .entry-title a",
+            "type": "attribute",
+            "attribute": "href",
+        },
+        {"name": "date", "selector": "time, .entry-date, .posted-on time", "type": "text"},
+        {
+            "name": "date_attr",
+            "selector": "time, .entry-date time",
+            "type": "attribute",
+            "attribute": "datetime",
+        },
+        {"name": "summary", "selector": ".entry-content, .entry-summary, .excerpt", "type": "text"},
+        {
+            "name": "pdf_url",
+            "selector": ".entry-content a[href$='.pdf'], .entry-summary a[href$='.pdf']",
+            "type": "attribute",
+            "attribute": "href",
+        },
+    ],
+}
+
+
+def parse_listing_rows(raw_rows: list[dict], source_url: str) -> list[JudgmentRecord]:
+    """Parse rows from JsonCssExtractionStrategy into JudgmentRecord models."""
+    records = []
+    for row in raw_rows:
+        title = row.get("title", "").strip()
+        if not title:
+            continue
+
+        case_number = _parse_case_number(title)
+
+        # Prefer datetime attribute (ISO format) over text date
+        date_raw = row.get("date_attr", "").strip() or row.get("date", "").strip()
+        decision_date_parsed = _parse_date(date_raw)
+
+        record = JudgmentRecord(
+            title=title,
+            case_number=case_number,
+            post_url=row.get("post_url", "").strip(),
+            pdf_url=row.get("pdf_url", "").strip(),
+            decision_date=date_raw,
+            decision_date_parsed=decision_date_parsed,
+            bench="",  # Populated from individual post page if needed
+            summary=row.get("summary", "").strip()[:500],
+            source_url=source_url,
+        )
+        records.append(record)
+
+    return records
+
+
+async def check_site_status() -> dict:
+    """Check if the Supreme Court website is accessible.
+
+    Returns a status dict with:
+    - accessible: bool
+    - maintenance: bool
+    - status_code: int or None
+    - message: str
+    """
+    from crawl4ai import AsyncWebCrawler, BrowserConfig, CrawlerRunConfig
+
+    browser_config = BrowserConfig(
+        headless=True,
+        enable_stealth=True,
+        extra_args=["--ignore-certificate-errors"],
+    )
+    run_config = CrawlerRunConfig(
+        wait_until="load",
+        page_timeout=30000,
+    )
+
+    try:
+        async with AsyncWebCrawler(config=browser_config) as crawler:
+            result = await crawler.arun(url=BASE_URL, config=run_config)
+
+            if not result.success:
+                return {
+                    "accessible": False,
+                    "maintenance": False,
+                    "status_code": result.status_code,
+                    "message": f"Crawl failed: {result.error_message}",
+                }
+
+            if _is_maintenance_page(result.html or ""):
+                return {
+                    "accessible": True,
+                    "maintenance": True,
+                    "status_code": result.status_code,
+                    "message": "Site is up but showing maintenance page",
+                }
+
+            return {
+                "accessible": True,
+                "maintenance": False,
+                "status_code": result.status_code,
+                "message": "Site is accessible",
+            }
+    except Exception as e:
+        return {
+            "accessible": False,
+            "maintenance": False,
+            "status_code": None,
+            "message": f"Connection error: {e}",
+        }
+
+
+async def crawl_listing_page(page: int = 1) -> tuple[list[JudgmentRecord], bool]:
+    """Crawl a single listing page of SC judgments.
+
+    Uses crawl4ai stealth mode to handle Akamai CDN protection.
+
+    Args:
+        page: Page number (1-indexed).
+
+    Returns:
+        Tuple of (records, has_next_page).
+
+    Raises:
+        SiteMaintenanceError: If site is in maintenance mode.
+        CrawlError: If crawl fails for other reasons.
+    """
+    from crawl4ai import (
+        AsyncWebCrawler,
+        BrowserConfig,
+        CacheMode,
+        CrawlerRunConfig,
+        JsonCssExtractionStrategy,
+    )
+
+    url = JUDGMENTS_URL if page == 1 else PAGINATION_TEMPLATE.format(page=page)
+
+    browser_config = BrowserConfig(
+        headless=True,
+        enable_stealth=True,
+        extra_args=["--ignore-certificate-errors"],
+    )
+
+    extraction_strategy = JsonCssExtractionStrategy(
+        schema=CSS_EXTRACTION_SCHEMA, verbose=False,
+    )
+
+    run_config = CrawlerRunConfig(
+        cache_mode=CacheMode.BYPASS,
+        wait_until="load",
+        magic=True,
+        delay_before_return_html=2.0,
+        page_timeout=60000,
+        extraction_strategy=extraction_strategy,
+    )
+
+    async with AsyncWebCrawler(config=browser_config) as crawler:
+        result = await crawler.arun(url=url, config=run_config)
+
+        if not result.success:
+            raise CrawlError(f"Page {page} crawl failed: {result.error_message}")
+
+        # Check for maintenance
+        if _is_maintenance_page(result.html or ""):
+            raise SiteMaintenanceError(
+                "Supreme Court website is currently down for maintenance"
+            )
+
+        # Parse records
+        records = []
+        if result.extracted_content:
+            try:
+                raw_rows = json.loads(result.extracted_content)
+                records = parse_listing_rows(raw_rows, url)
+            except json.JSONDecodeError as e:
+                raise CrawlError(f"Failed to parse extracted JSON: {e}") from e
+
+        # Check for next page link in HTML
+        has_next = _has_next_page(result.html or "", page)
+
+        logger.info("Page %d: extracted %d judgment records", page, len(records))
+        return records, has_next
+
+
+def _has_next_page(html: str, current_page: int) -> bool:
+    """Check if there's a next page link in the pagination HTML."""
+    next_page = current_page + 1
+    # WordPress pagination: /page/N/
+    patterns = [
+        f"/page/{next_page}/",
+        'class="next"',
+        "next page-numbers",
+    ]
+    return any(p in html for p in patterns)
+
+
+async def crawl_all_listings(max_pages: int = MAX_PAGES) -> list[JudgmentRecord]:
+    """Crawl all paginated listing pages for SC judgments.
+
+    Args:
+        max_pages: Safety limit on number of pages to crawl.
+
+    Returns:
+        Combined list of JudgmentRecord from all pages.
+
+    Raises:
+        SiteMaintenanceError: If site is in maintenance mode.
+        CrawlError: If crawl fails.
+    """
+    all_records: list[JudgmentRecord] = []
+    seen_urls: set[str] = set()
+
+    for page in range(1, max_pages + 1):
+        records, has_next = await crawl_listing_page(page)
+
+        # Deduplicate by post URL
+        for record in records:
+            if record.post_url and record.post_url not in seen_urls:
+                seen_urls.add(record.post_url)
+                all_records.append(record)
+
+        if not has_next or not records:
+            logger.info("Pagination ended at page %d", page)
+            break
+
+        # Respect rate limits
+        await asyncio.sleep(REQUEST_DELAY_SECONDS)
+
+    logger.info("Total: %d unique judgment records from %d pages", len(all_records), page)
+    return all_records
+
+
+async def extract_pdf_from_post(post_url: str) -> str:
+    """Visit an individual judgment post page and extract the PDF link.
+
+    Some judgment posts may not have PDF links in the listing excerpt.
+    This function visits the full post page to find PDF download links.
+
+    Args:
+        post_url: Full URL to the judgment post page.
+
+    Returns:
+        PDF URL if found, empty string otherwise.
+    """
+    from crawl4ai import (
+        AsyncWebCrawler,
+        BrowserConfig,
+        CacheMode,
+        CrawlerRunConfig,
+    )
+
+    browser_config = BrowserConfig(
+        headless=True,
+        enable_stealth=True,
+        extra_args=["--ignore-certificate-errors"],
+    )
+
+    run_config = CrawlerRunConfig(
+        cache_mode=CacheMode.BYPASS,
+        wait_until="load",
+        magic=True,
+        delay_before_return_html=1.0,
+        page_timeout=30000,
+    )
+
+    try:
+        async with AsyncWebCrawler(config=browser_config) as crawler:
+            result = await crawler.arun(url=post_url, config=run_config)
+
+            if not result.success:
+                logger.warning("Failed to load post: %s", post_url)
+                return ""
+
+            # Find PDF links in the page HTML
+            pdf_links = re.findall(
+                r'href=["\']([^"\']*\.pdf)["\']',
+                result.html or "",
+                re.IGNORECASE,
+            )
+
+            if pdf_links:
+                # Return the first PDF link, make absolute if relative
+                pdf_url = pdf_links[0]
+                if pdf_url.startswith("/"):
+                    pdf_url = BASE_URL + pdf_url
+                return pdf_url
+
+    except Exception as e:
+        logger.error("Error extracting PDF from %s: %s", post_url, e)
+
+    return ""

--- a/src/pipelines/supreme_court/pipeline.py
+++ b/src/pipelines/supreme_court/pipeline.py
@@ -1,0 +1,309 @@
+"""Supreme Court of Pakistan crawler pipeline.
+
+Orchestrates the full flow: listing crawl → post visit → PDF download → text output.
+Single responsibility: coordinate the pipeline stages with crash resilience.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+
+from src.extractors.common.pdf_extract import download_and_extract
+
+from .constants import COURT_CODE, REQUEST_DELAY_SECONDS
+from .errors import SiteMaintenanceError
+from .listing import (
+    JudgmentRecord,
+    check_site_status,
+    crawl_all_listings,
+    extract_pdf_from_post,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OUTPUT_DIR = Path(
+    os.environ.get("SC_OUTPUT_DIR", "data/supreme_court")
+)
+
+CHECKPOINT_INTERVAL = 25
+
+
+async def crawl_full(
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    limit: int | None = None,
+    skip_site_check: bool = False,
+) -> list[dict]:
+    """Crawl Supreme Court judgments and extract PDF text.
+
+    Args:
+        output_dir: Directory to save results and PDFs.
+        limit: Max number of judgments to process. None for all.
+        skip_site_check: Skip the maintenance check (for testing).
+
+    Returns:
+        List of result dicts with metadata + extracted text.
+
+    Raises:
+        SiteMaintenanceError: If site is in maintenance mode.
+        CrawlError: If the listing pages cannot be crawled.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    pdf_dir = output_dir / "pdfs"
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+
+    # Stage 0: Check if site is accessible
+    if not skip_site_check:
+        logger.info("Stage 0: Checking site accessibility...")
+        site_status = await check_site_status()
+        logger.info("Site status: %s", site_status["message"])
+
+        if site_status["maintenance"]:
+            raise SiteMaintenanceError(site_status["message"])
+
+        if not site_status["accessible"]:
+            raise SiteMaintenanceError(
+                f"Site not accessible: {site_status['message']}"
+            )
+
+    # Stage 1: Crawl judgment listings
+    logger.info("Stage 1: Crawling judgment listings...")
+    records = await crawl_all_listings()
+    logger.info("Found %d judgment records", len(records))
+
+    if limit:
+        records = records[:limit]
+        logger.info("Limited to %d records", limit)
+
+    # Stage 2: Enrich records with PDF links from individual posts
+    records = await _enrich_pdf_links(records)
+
+    # Stage 3: Download PDFs and extract text
+    results = await _process_records(records, pdf_dir)
+
+    # Save results
+    _save_results(results, output_dir / "results.jsonl")
+    _save_summary(results, output_dir / "summary.json")
+    return results
+
+
+async def _enrich_pdf_links(
+    records: list[JudgmentRecord],
+) -> list[JudgmentRecord]:
+    """Visit individual post pages to find PDF links for records missing them."""
+    enriched = 0
+    for idx, record in enumerate(records):
+        if record.pdf_url:
+            continue
+
+        if not record.post_url:
+            continue
+
+        logger.info(
+            "[%d/%d] Enriching PDF link for: %s",
+            idx + 1, len(records), record.case_number,
+        )
+
+        pdf_url = await extract_pdf_from_post(record.post_url)
+        if pdf_url:
+            record = record.model_copy(update={"pdf_url": pdf_url})
+            records[idx] = record
+            enriched += 1
+
+        await asyncio.sleep(REQUEST_DELAY_SECONDS)
+
+    if enriched:
+        logger.info("Enriched %d records with PDF links", enriched)
+
+    return records
+
+
+async def _process_records(
+    records: list[JudgmentRecord],
+    pdf_dir: Path,
+) -> list[dict]:
+    """Download PDFs and extract text for each judgment record.
+
+    Per-record error isolation so one failure doesn't kill the batch.
+    Checkpoint saves every CHECKPOINT_INTERVAL records.
+    """
+    results: list[dict] = []
+    seen_urls: set[str] = set()
+    checkpoint_path = pdf_dir.parent / "checkpoint.jsonl"
+    failed_count = 0
+
+    for idx, record in enumerate(records):
+        # Deduplicate by PDF URL
+        if record.pdf_url and record.pdf_url in seen_urls:
+            logger.debug("Skipping duplicate PDF: %s", record.pdf_url)
+            continue
+        if record.pdf_url:
+            seen_urls.add(record.pdf_url)
+
+        try:
+            result = await _process_single_record(record, pdf_dir)
+            results.append(result)
+
+            if result["text"]:
+                logger.info(
+                    "[%d/%d] OK: %s — %d chars",
+                    idx + 1, len(records),
+                    record.case_number or "?",
+                    result["text_length"],
+                )
+            else:
+                logger.warning(
+                    "[%d/%d] EMPTY: %s — no text extracted",
+                    idx + 1, len(records),
+                    record.case_number or record.post_url,
+                )
+
+        except Exception as e:
+            failed_count += 1
+            logger.error(
+                "[%d/%d] FAILED: %s: %s",
+                idx + 1, len(records), record.case_number, e,
+                exc_info=True,
+            )
+            results.append({
+                **record.model_dump(),
+                "text": "",
+                "text_length": 0,
+                "error": str(e),
+                "source": "supreme_court",
+                "court": COURT_CODE,
+            })
+
+        # Checkpoint save
+        if len(results) % CHECKPOINT_INTERVAL == 0 and results:
+            _save_results(results, checkpoint_path)
+            logger.info("Checkpoint: %d results saved", len(results))
+
+    with_text = sum(1 for r in results if r["text"])
+    logger.info(
+        "Processed %d records: %d with text, %d empty, %d failed",
+        len(results), with_text, len(results) - with_text - failed_count, failed_count,
+    )
+    return results
+
+
+async def _process_single_record(
+    record: JudgmentRecord,
+    pdf_dir: Path,
+) -> dict:
+    """Download PDF and extract text for a single judgment record."""
+    text = ""
+    if record.pdf_url:
+        text = await download_and_extract(record.pdf_url, pdf_dir)
+    else:
+        logger.warning("No PDF URL for %s", record.case_number)
+
+    return {
+        **record.model_dump(),
+        "text": text,
+        "text_length": len(text),
+        "source": "supreme_court",
+        "court": COURT_CODE,
+    }
+
+
+def _save_results(results: list[dict], path: Path) -> None:
+    """Save results as JSONL."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(path, "w") as f:
+            for result in results:
+                row = {}
+                for k, v in result.items():
+                    if hasattr(v, "isoformat"):
+                        row[k] = v.isoformat()
+                    else:
+                        row[k] = v
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+        logger.info("Saved %d results to %s", len(results), path)
+    except (OSError, TypeError) as e:
+        logger.error("Failed to save results to %s: %s", path, e)
+        raise
+
+
+def _save_summary(results: list[dict], path: Path) -> None:
+    """Save a summary of the crawl run."""
+    with_text = sum(1 for r in results if r.get("text"))
+    errors = sum(1 for r in results if r.get("error"))
+
+    summary = {
+        "total_records": len(results),
+        "with_text": with_text,
+        "empty_text": len(results) - with_text,
+        "errors": errors,
+        "records": [
+            {
+                "case_number": r.get("case_number"),
+                "title": r.get("title"),
+                "decision_date": r.get("decision_date"),
+                "text_length": r.get("text_length", 0),
+                "error": r.get("error"),
+            }
+            for r in results
+        ],
+    }
+    try:
+        with open(path, "w") as f:
+            json.dump(summary, f, indent=2, ensure_ascii=False)
+    except (OSError, TypeError) as e:
+        logger.error("Failed to save summary to %s: %s", path, e)
+
+
+async def main():
+    """CLI entry point."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Supreme Court of Pakistan Judgment Crawler"
+    )
+    parser.add_argument(
+        "--limit", type=int, default=None,
+        help="Max judgments to process",
+    )
+    parser.add_argument(
+        "--output", type=str, default=str(DEFAULT_OUTPUT_DIR),
+    )
+    parser.add_argument(
+        "--check-only", action="store_true",
+        help="Only check if the site is accessible, don't crawl",
+    )
+    args = parser.parse_args()
+
+    if args.check_only:
+        result = await check_site_status()
+        logger.info("Status: %s", result)
+        return
+
+    output_dir = Path(args.output)
+
+    try:
+        results = await crawl_full(output_dir=output_dir, limit=args.limit)
+        with_text = sum(1 for r in results if r["text"])
+        errors = sum(1 for r in results if r.get("error"))
+        logger.info(
+            "Done: %d records, %d with text, %d errors",
+            len(results), with_text, errors,
+        )
+    except SiteMaintenanceError as e:
+        logger.error("Cannot crawl: %s", e)
+        logger.info(
+            "The Supreme Court website is currently under maintenance. "
+            "Try again later or use --check-only to monitor status."
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_supreme_court.py
+++ b/tests/test_supreme_court.py
@@ -1,0 +1,295 @@
+"""Tests for the Supreme Court of Pakistan crawler pipeline.
+
+Tests parsing logic with sample data based on Wayback Machine recon.
+Does NOT hit the live website — all tests use offline sample data.
+"""
+
+from datetime import date
+
+import pytest
+
+from src.pipelines.supreme_court.constants import (
+    BASE_URL,
+    COURT_CODE,
+    JUDGMENTS_URL,
+    MAINTENANCE_MARKERS,
+    PAGINATION_TEMPLATE,
+)
+from src.pipelines.supreme_court.errors import (
+    CrawlError,
+    ExtractionError,
+    SiteMaintenanceError,
+)
+from src.pipelines.supreme_court.listing import (
+    JudgmentRecord,
+    _has_next_page,
+    _is_maintenance_page,
+    _parse_case_number,
+    _parse_date,
+    parse_listing_rows,
+)
+
+
+class TestConstants:
+    def test_base_url(self):
+        assert "supremecourt.gov.pk" in BASE_URL
+
+    def test_court_code(self):
+        assert COURT_CODE == "SC"
+
+    def test_pagination_template(self):
+        url = PAGINATION_TEMPLATE.format(page=3)
+        assert "/page/3/" in url
+
+    def test_judgments_url(self):
+        assert JUDGMENTS_URL.endswith("/category/judgements/")
+
+
+class TestErrors:
+    def test_crawl_error_is_exception(self):
+        with pytest.raises(CrawlError):
+            raise CrawlError("test")
+
+    def test_extraction_error_is_exception(self):
+        with pytest.raises(ExtractionError):
+            raise ExtractionError("test")
+
+    def test_maintenance_error_is_crawl_error(self):
+        err = SiteMaintenanceError("down")
+        assert isinstance(err, CrawlError)
+
+
+class TestParseCaseNumber:
+    def test_constitution_petition(self):
+        result = _parse_case_number("Constitution Petition No. 39 of 2019")
+        assert result == "Constitution Petition No. 39 of 2019"
+
+    def test_civil_appeal(self):
+        result = _parse_case_number("Civil Appeal No. 1234 of 2023")
+        assert result == "Civil Appeal No. 1234 of 2023"
+
+    def test_criminal_appeal(self):
+        result = _parse_case_number("Criminal Appeal No. 567 of 2022")
+        assert result == "Criminal Appeal No. 567 of 2022"
+
+    def test_smc(self):
+        result = _parse_case_number("SMC No. 1 of 2024")
+        assert result == "SMC No. 1 of 2024"
+
+    def test_hrc(self):
+        result = _parse_case_number("HRC No. 42 of 2020")
+        assert result == "HRC No. 42 of 2020"
+
+    def test_writ_petition(self):
+        result = _parse_case_number("W.P No. 100 of 2023")
+        assert result == "W.P No. 100 of 2023"
+
+    def test_abbreviated_criminal(self):
+        result = _parse_case_number("Cr. Appeal No. 200 of 2021")
+        assert result == "Cr. Appeal No. 200 of 2021"
+
+    def test_no_match_returns_full_title(self):
+        title = "Some random announcement"
+        assert _parse_case_number(title) == title
+
+    def test_empty_string(self):
+        assert _parse_case_number("") == ""
+
+    def test_whitespace_stripped(self):
+        result = _parse_case_number("  Civil Appeal No. 5 of 2024  ")
+        assert result == "Civil Appeal No. 5 of 2024"
+
+
+class TestParseDate:
+    def test_wordpress_format(self):
+        assert _parse_date("December 23, 2024") == date(2024, 12, 23)
+
+    def test_wordpress_format_no_comma(self):
+        assert _parse_date("January 5 2023") == date(2023, 1, 5)
+
+    def test_abbreviated_month(self):
+        assert _parse_date("Jan 15, 2024") == date(2024, 1, 15)
+
+    def test_dd_mm_yyyy(self):
+        assert _parse_date("23-12-2024") == date(2024, 12, 23)
+
+    def test_iso_format(self):
+        assert _parse_date("2024-12-23") == date(2024, 12, 23)
+
+    def test_empty(self):
+        assert _parse_date("") is None
+
+    def test_invalid(self):
+        assert _parse_date("not-a-date") is None
+
+    def test_whitespace(self):
+        assert _parse_date("  December 23, 2024  ") == date(2024, 12, 23)
+
+
+class TestIsMaintenancePage:
+    def test_maintenance_detected(self):
+        html = "<h1>Site Under Maintenance</h1><p>We apologize...</p>"
+        assert _is_maintenance_page(html) is True
+
+    def test_back_soon_detected(self):
+        html = "<h1>We'll Be Back Soon</h1>"
+        assert _is_maintenance_page(html) is True
+
+    def test_down_for_maintenance(self):
+        html = "This site is currently down for maintenance."
+        assert _is_maintenance_page(html) is True
+
+    def test_normal_page_not_detected(self):
+        html = "<html><body><h1>Supreme Court of Pakistan</h1></body></html>"
+        assert _is_maintenance_page(html) is False
+
+    def test_empty_html(self):
+        assert _is_maintenance_page("") is False
+
+    def test_case_insensitive(self):
+        html = "<h1>SITE UNDER MAINTENANCE</h1>"
+        assert _is_maintenance_page(html) is True
+
+
+class TestParseListingRows:
+    @pytest.fixture
+    def sample_rows(self):
+        return [
+            {
+                "title": "Constitution Petition No. 39 of 2019",
+                "post_url": "https://www.supremecourt.gov.pk/constitution-petition-no-39-of-2019/",
+                "date": "August 6, 2024",
+                "date_attr": "2024-08-06",
+                "summary": "The court examined the constitutional validity...",
+                "pdf_url": "https://www.supremecourt.gov.pk/wp-content/uploads/2024/08/cp39-2019.pdf",
+            },
+            {
+                "title": "Civil Appeal No. 1500 of 2023",
+                "post_url": "https://www.supremecourt.gov.pk/civil-appeal-no-1500-of-2023/",
+                "date": "July 15, 2024",
+                "date_attr": "",
+                "summary": "Appeal against High Court decision in property dispute.",
+                "pdf_url": "",
+            },
+        ]
+
+    def test_parses_records(self, sample_rows):
+        records = parse_listing_rows(sample_rows, "test_source")
+        assert len(records) == 2
+        assert all(isinstance(r, JudgmentRecord) for r in records)
+
+    def test_case_number_extracted(self, sample_rows):
+        records = parse_listing_rows(sample_rows, "test_source")
+        assert records[0].case_number == "Constitution Petition No. 39 of 2019"
+        assert records[1].case_number == "Civil Appeal No. 1500 of 2023"
+
+    def test_date_prefers_datetime_attr(self, sample_rows):
+        records = parse_listing_rows(sample_rows, "test_source")
+        assert records[0].decision_date == "2024-08-06"
+        assert records[0].decision_date_parsed == date(2024, 8, 6)
+
+    def test_date_falls_back_to_text(self, sample_rows):
+        records = parse_listing_rows(sample_rows, "test_source")
+        assert records[1].decision_date == "July 15, 2024"
+        assert records[1].decision_date_parsed == date(2024, 7, 15)
+
+    def test_pdf_url_captured(self, sample_rows):
+        records = parse_listing_rows(sample_rows, "test_source")
+        assert records[0].pdf_url.endswith(".pdf")
+        assert records[1].pdf_url == ""
+
+    def test_summary_captured(self, sample_rows):
+        records = parse_listing_rows(sample_rows, "test_source")
+        assert "constitutional" in records[0].summary.lower()
+
+    def test_source_url_set(self, sample_rows):
+        records = parse_listing_rows(sample_rows, "test_source")
+        assert all(r.source_url == "test_source" for r in records)
+
+    def test_empty_title_skipped(self):
+        rows = [{"title": "", "post_url": "http://example.com"}]
+        records = parse_listing_rows(rows, "test")
+        assert records == []
+
+    def test_empty_list(self):
+        records = parse_listing_rows([], "test")
+        assert records == []
+
+    def test_missing_fields(self):
+        rows = [{"title": "Civil Appeal No. 5 of 2024"}]
+        records = parse_listing_rows(rows, "test")
+        assert len(records) == 1
+        assert records[0].pdf_url == ""
+        assert records[0].post_url == ""
+
+    def test_summary_truncated(self):
+        rows = [{"title": "Test Case", "summary": "x" * 1000}]
+        records = parse_listing_rows(rows, "test")
+        assert len(records[0].summary) <= 500
+
+
+class TestHasNextPage:
+    def test_next_page_link(self):
+        html = '<a href="/category/judgements/page/3/" class="next">Next</a>'
+        assert _has_next_page(html, 2) is True
+
+    def test_next_class(self):
+        html = '<a class="next" href="/page/2/">Next Page</a>'
+        assert _has_next_page(html, 1) is True
+
+    def test_no_next_page(self):
+        html = '<div class="pagination"><a href="/page/1/">1</a></div>'
+        assert _has_next_page(html, 5) is False
+
+    def test_empty_html(self):
+        assert _has_next_page("", 1) is False
+
+    def test_page_numbers_class(self):
+        html = '<a class="next page-numbers" href="/page/4/">Next</a>'
+        assert _has_next_page(html, 3) is True
+
+
+class TestJudgmentRecordModel:
+    def test_create_record(self):
+        record = JudgmentRecord(
+            title="Constitution Petition No. 39 of 2019",
+            case_number="Constitution Petition No. 39 of 2019",
+            post_url="https://www.supremecourt.gov.pk/cp-39-2019/",
+            pdf_url="https://www.supremecourt.gov.pk/wp-content/uploads/cp39.pdf",
+            decision_date="2024-08-06",
+            decision_date_parsed=date(2024, 8, 6),
+            bench="Justice A, Justice B",
+            summary="Constitutional validity examined.",
+            source_url="https://www.supremecourt.gov.pk/category/judgements/",
+        )
+        assert record.title == "Constitution Petition No. 39 of 2019"
+        assert record.bench == "Justice A, Justice B"
+
+    def test_optional_date(self):
+        record = JudgmentRecord(
+            title="Test",
+            case_number="Test",
+            post_url="",
+            pdf_url="",
+            decision_date="",
+            bench="",
+            summary="",
+            source_url="test",
+        )
+        assert record.decision_date_parsed is None
+
+    def test_model_dump(self):
+        record = JudgmentRecord(
+            title="Test",
+            case_number="Test No. 1 of 2024",
+            post_url="http://example.com",
+            pdf_url="",
+            decision_date="2024-01-01",
+            decision_date_parsed=date(2024, 1, 1),
+            bench="",
+            summary="Test summary",
+            source_url="test",
+        )
+        data = record.model_dump()
+        assert data["case_number"] == "Test No. 1 of 2024"
+        assert data["decision_date_parsed"] == date(2024, 1, 1)


### PR DESCRIPTION
## Summary
- Pipeline ready with crawl4ai stealth/undetected browser mode for when site comes back
- Supreme Court website currently down for maintenance (served by NADRA/Akamai)
- WordPress-based site with judgments at /category/judgements/
- Maintenance detection, stealth crawling, WordPress pagination support
- 50 offline tests

## Site Status
- supremecourt.gov.pk returns maintenance page
- All sub-paths return 404 from Akamai CDN
- No alternative subdomains exist
- Pipeline will auto-detect when site is back online

## Test plan
- [x] 50 offline unit tests pass
- [ ] Live validation pending site restoration

Ref #1