### PR TITLE
Add Lahore High Court crawler pipeline (#2)

### DIFF
--- a/src/pipelines/lahore_hc/constants.py
+++ b/src/pipelines/lahore_hc/constants.py
@@ -1,0 +1,17 @@
+"""Shared constants for the Lahore High Court crawler pipeline."""
+
+BASE_URL = "https://data.lhc.gov.pk"
+JUDGMENTS_URL = f"{BASE_URL}/reported_judgments/judgments_approved_for_reporting"
+FORMER_JUDGES_URL = (
+    f"{BASE_URL}/reported_judgments/judgments_approved_for_reporting_by_former_judges"
+)
+DYNAMIC_RESULTS_URL = f"{BASE_URL}/dynamic/approved_judgments_result_new.php"
+
+# PDF judgments are served from a separate subdomain
+PDF_BASE_URL = "https://sys.lhc.gov.pk/appjudgments"
+
+# Available filter values discovered via recon
+YEARS = list(range(2010, 2027))
+
+# Court code used in Qdrant point IDs
+COURT_CODE = "LHC"

--- a/src/pipelines/lahore_hc/errors.py
+++ b/src/pipelines/lahore_hc/errors.py
@@ -1,0 +1,9 @@
+"""Custom exceptions for the Lahore HC crawler pipeline."""
+
+
+class CrawlError(Exception):
+    """Raised when a crawl operation fails irrecoverably."""
+
+
+class ExtractionError(Exception):
+    """Raised when data extraction from HTML/PDF fails."""

--- a/src/pipelines/lahore_hc/listing.py
+++ b/src/pipelines/lahore_hc/listing.py
@@ -1,0 +1,405 @@
+"""Crawl Lahore HC reported judgments and extract case metadata.
+
+Single responsibility: form/search page → list of JudgmentRecord.
+
+The LHC website at data.lhc.gov.pk serves reported judgments via:
+1. A search form at /reported_judgments/judgments_approved_for_reporting
+2. A dynamic PHP endpoint at /dynamic/approved_judgments_result_new.php?year=
+3. PDFs hosted at sys.lhc.gov.pk/appjudgments/{year}LHC{number}.pdf
+
+The site is behind FortiGuard IPS which blocks access from outside Pakistan.
+When accessible, it uses a jQuery DataTable for results display.
+
+Uses crawl4ai native features:
+- session_id for multi-step form interaction
+- JsonCssExtractionStrategy for structured row extraction
+- wait_until="networkidle" for reliability
+
+Expected table columns (based on similar LHC court interfaces):
+  0: S.No (serial number)
+  1: Case No (case number)
+  2: Case Title (parties)
+  3: Judge Name (deciding judge)
+  4: LHC Citation (e.g. "2024 LHC 4177")
+  5: Other Citation (PLD, CLC, etc.)
+  6: Category (Criminal, Civil, etc.)
+  7: Decision Date (dd-mm-yyyy or dd/mm/yyyy)
+  8: Judgment (PDF link)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import date
+
+from pydantic import BaseModel
+
+from .constants import JUDGMENTS_URL, PDF_BASE_URL
+from .errors import CrawlError
+
+logger = logging.getLogger(__name__)
+
+
+class JudgmentRecord(BaseModel):
+    """A single judgment row extracted from the LHC DataTable."""
+
+    serial: int
+    case_number: str
+    case_title: str
+    judge_name: str
+    lhc_citation: str
+    other_citation: str
+    category: str
+    decision_date: str
+    decision_date_parsed: date | None = None
+    pdf_url: str
+    source_url: str
+
+
+def _parse_date(raw: str) -> date | None:
+    """Parse date string in dd-mm-yyyy or dd/mm/yyyy format."""
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        # Handle both dd-mm-yyyy and dd/mm/yyyy
+        parts = re.split(r"[-/]", raw)
+        if len(parts) == 3:
+            return date(int(parts[2]), int(parts[1]), int(parts[0]))
+    except (ValueError, IndexError):
+        pass
+    logger.debug("Could not parse date: %s", raw)
+    return None
+
+
+def _normalize_pdf_url(raw_url: str) -> str:
+    """Normalize a PDF URL to ensure it's absolute and well-formed.
+
+    LHC PDFs are hosted at sys.lhc.gov.pk/appjudgments/ with the pattern
+    {year}LHC{number}.pdf (e.g. 2024LHC4177.pdf).
+    """
+    raw_url = raw_url.strip()
+    if not raw_url:
+        return ""
+
+    # Already absolute
+    if raw_url.startswith("http://") or raw_url.startswith("https://"):
+        return raw_url
+
+    # Relative path — prepend base URL
+    if raw_url.startswith("/"):
+        return f"https://sys.lhc.gov.pk{raw_url}"
+
+    # Just a filename like "2024LHC4177.pdf"
+    if raw_url.endswith(".pdf"):
+        return f"{PDF_BASE_URL}/{raw_url}"
+
+    return raw_url
+
+
+def _extract_pdf_url_from_html(html_snippet: str) -> str:
+    """Extract PDF URL from an HTML snippet containing an <a> tag."""
+    match = re.search(r'href=["\']([^"\']*\.pdf[^"\']*)["\']', html_snippet, re.I)
+    if match:
+        return _normalize_pdf_url(match.group(1))
+    return ""
+
+
+# Column names matching the expected LHC table headers
+TABLE_HEADERS = [
+    "S.No", "Case No", "Case Title", "Judge Name",
+    "LHC Citation", "Other Citation", "Category",
+    "Decision Date", "Judgment",
+]
+
+
+def parse_table_data(table_data: dict, source_url: str) -> list[JudgmentRecord]:
+    """Parse a crawl4ai table extraction result into JudgmentRecord models.
+
+    Args:
+        table_data: Dict with 'headers' and 'rows' from DefaultTableExtraction.
+        source_url: Source URL for provenance tracking.
+    """
+    headers = table_data.get("headers", [])
+    rows = table_data.get("rows", [])
+
+    if not rows:
+        return []
+
+    records = []
+    for row in rows:
+        row_dict = dict(zip(headers, row)) if headers else {}
+        if not row_dict:
+            if len(row) < 8:
+                continue
+            row_dict = dict(zip(TABLE_HEADERS, row))
+
+        decision_date_raw = row_dict.get("Decision Date", "").strip()
+
+        record = JudgmentRecord(
+            serial=int(row_dict.get("S.No", 0) or 0),
+            case_number=row_dict.get("Case No", "").strip(),
+            case_title=row_dict.get("Case Title", "").strip(),
+            judge_name=row_dict.get("Judge Name", "").strip(),
+            lhc_citation=row_dict.get("LHC Citation", "").strip(),
+            other_citation=row_dict.get("Other Citation", "").strip(),
+            category=row_dict.get("Category", "").strip(),
+            decision_date=decision_date_raw,
+            decision_date_parsed=_parse_date(decision_date_raw),
+            pdf_url=_extract_pdf_url_from_html(
+                row_dict.get("Judgment", "")
+            ),
+            source_url=source_url,
+        )
+        records.append(record)
+
+    return records
+
+
+def parse_css_rows(raw_rows: list[dict], source_url: str) -> list[JudgmentRecord]:
+    """Parse rows from JsonCssExtractionStrategy into JudgmentRecord models."""
+    records = []
+    for row in raw_rows:
+        decision_date_raw = row.get("decision_date", "").strip()
+
+        record = JudgmentRecord(
+            serial=int(row.get("serial", 0) or 0),
+            case_number=row.get("case_number", "").strip(),
+            case_title=row.get("case_title", "").strip(),
+            judge_name=row.get("judge_name", "").strip(),
+            lhc_citation=row.get("lhc_citation", "").strip(),
+            other_citation=row.get("other_citation", "").strip(),
+            category=row.get("category", "").strip(),
+            decision_date=decision_date_raw,
+            decision_date_parsed=_parse_date(decision_date_raw),
+            pdf_url=_normalize_pdf_url(row.get("pdf_url", "").strip()),
+            source_url=source_url,
+        )
+        records.append(record)
+
+    return records
+
+
+# JsonCssExtractionStrategy schema for the LHC DataTable rows.
+# The exact CSS selectors may need adjustment after verifying the live site
+# structure from within Pakistan (site is geo-blocked by FortiGuard).
+# These selectors follow the standard DataTable pattern used by Pakistani
+# court websites (same infrastructure as PHC).
+CSS_EXTRACTION_SCHEMA = {
+    "name": "LHC Judgments",
+    "baseSelector": "table tbody tr",
+    "fields": [
+        {"name": "serial", "selector": "td:nth-child(1)", "type": "text"},
+        {"name": "case_number", "selector": "td:nth-child(2)", "type": "text"},
+        {"name": "case_title", "selector": "td:nth-child(3)", "type": "text"},
+        {"name": "judge_name", "selector": "td:nth-child(4)", "type": "text"},
+        {"name": "lhc_citation", "selector": "td:nth-child(5)", "type": "text"},
+        {"name": "other_citation", "selector": "td:nth-child(6)", "type": "text"},
+        {"name": "category", "selector": "td:nth-child(7)", "type": "text"},
+        {"name": "decision_date", "selector": "td:nth-child(8)", "type": "text"},
+        {
+            "name": "pdf_url",
+            "selector": "td:nth-child(9) a",
+            "type": "attribute",
+            "attribute": "href",
+        },
+    ],
+}
+
+
+def _build_submit_js(year: int | None = None) -> str:
+    """Build JavaScript to fill and submit the search form.
+
+    The LHC form uses a year dropdown filter. Additional filters (judge,
+    category) may be available but require live site verification.
+    """
+    parts = []
+    if year is not None:
+        # Try multiple common selector patterns for the year dropdown
+        parts.append(f"""
+        (function() {{
+            var selectors = ['#year', '#ddlYear', 'select[name="year"]', 'select[name="ddlYear"]'];
+            for (var i = 0; i < selectors.length; i++) {{
+                var el = document.querySelector(selectors[i]);
+                if (el) {{
+                    el.value = '{year}';
+                    el.dispatchEvent(new Event('change', {{ bubbles: true }}));
+                    break;
+                }}
+            }}
+        }})();
+        """)
+    # Try multiple submit button selector patterns
+    parts.append("""
+    (function() {
+        var selectors = [
+            'input[type="submit"]', 'button[type="submit"]',
+            '#btnSearch', '#btnSubmit', '.btn-primary',
+            'input[value="Search"]', 'button:contains("Search")'
+        ];
+        for (var i = 0; i < selectors.length; i++) {
+            var el = document.querySelector(selectors[i]);
+            if (el) {
+                el.click();
+                break;
+            }
+        }
+    })();
+    """)
+    return "\n".join(parts)
+
+
+async def crawl_judgments(
+    year: int | None = None,
+    category: str | None = None,
+) -> list[JudgmentRecord]:
+    """Crawl LHC reported judgments by submitting the search form.
+
+    Two-step crawl4ai session approach:
+    1. Load form page, fill year field, submit (triggers navigation).
+       crawl4ai handles the navigation automatically.
+    2. On the results page (same session, js_only=True), expand DataTable
+       to show all rows, then extract with JsonCssExtractionStrategy.
+
+    The LHC site is behind FortiGuard IPS which blocks access from outside
+    Pakistan. The crawler will raise CrawlError with a clear message if
+    the site is unreachable or returns 403.
+
+    Args:
+        year: Filter by year (2010-2026). None for all years.
+        category: Filter by category (client-side). None for all.
+
+    Returns:
+        List of JudgmentRecord extracted from the results table.
+
+    Raises:
+        CrawlError: If the page cannot be loaded or extraction fails.
+    """
+    from crawl4ai import (
+        AsyncWebCrawler,
+        BrowserConfig,
+        CacheMode,
+        CrawlerRunConfig,
+        JsonCssExtractionStrategy,
+    )
+
+    browser_config = BrowserConfig(
+        headless=True,
+        extra_args=["--ignore-certificate-errors"],
+    )
+
+    submit_js = _build_submit_js(year)
+
+    # Script 2: Expand DataTable to show all rows after results load
+    expand_datatable_js = """
+    (async () => {
+        // Poll until jQuery DataTable is initialized (up to 15s)
+        for (let i = 0; i < 30; i++) {
+            if (typeof $ !== 'undefined' && $.fn.DataTable) {
+                var tables = $('table').filter(function() {
+                    return $.fn.DataTable.isDataTable(this);
+                });
+                if (tables.length > 0) {
+                    var dt = tables.first().DataTable();
+                    dt.page.len(-1).draw();
+                    await new Promise(r => setTimeout(r, 500));
+                    return;
+                }
+            }
+            await new Promise(r => setTimeout(r, 500));
+        }
+    })();
+    """
+
+    extraction_strategy = JsonCssExtractionStrategy(
+        schema=CSS_EXTRACTION_SCHEMA, verbose=False,
+    )
+
+    session_id = "lhc_session"
+
+    async with AsyncWebCrawler(config=browser_config) as crawler:
+        # Step 1: Load form page, fill, and submit
+        step1_config = CrawlerRunConfig(
+            session_id=session_id,
+            cache_mode=CacheMode.BYPASS,
+            wait_until="networkidle",
+            js_code=submit_js,
+            delay_before_return_html=5.0,
+            page_timeout=90000,
+        )
+        result = await crawler.arun(url=JUDGMENTS_URL, config=step1_config)
+
+        if not result.success:
+            # Check for FortiGuard / geo-block
+            if result.status_code == 403:
+                raise CrawlError(
+                    "LHC site returned 403 Forbidden. The site is behind "
+                    "FortiGuard IPS and may only be accessible from within "
+                    "Pakistan. Error: " + (result.error_message or "")
+                )
+            raise CrawlError(f"Form submission failed: {result.error_message}")
+
+        # Check for FortiGuard block in successful response
+        if result.status_code == 403:
+            raise CrawlError(
+                "LHC site returned 403 Forbidden (FortiGuard IPS block). "
+                "The site may only be accessible from within Pakistan."
+            )
+
+        # Step 2: Expand DataTable and extract data
+        step2_config = CrawlerRunConfig(
+            session_id=session_id,
+            cache_mode=CacheMode.BYPASS,
+            js_only=True,
+            js_code=expand_datatable_js,
+            wait_for="css:table",
+            delay_before_return_html=2.0,
+            extraction_strategy=extraction_strategy,
+            page_timeout=30000,
+        )
+        result = await crawler.arun(url=JUDGMENTS_URL, config=step2_config)
+
+        if not result.success:
+            raise CrawlError(f"Data extraction failed: {result.error_message}")
+
+        # Parse extracted content
+        records = []
+        if result.extracted_content:
+            try:
+                raw_rows = json.loads(result.extracted_content)
+                records = parse_css_rows(raw_rows, JUDGMENTS_URL)
+            except json.JSONDecodeError as e:
+                raise CrawlError(f"Failed to parse extracted JSON: {e}") from e
+
+    # Client-side category filter
+    if category and records:
+        before = len(records)
+        records = [r for r in records if r.category.lower() == category.lower()]
+        logger.info(
+            "Category filter '%s': %d → %d records",
+            category, before, len(records),
+        )
+
+    if not records:
+        logger.warning(
+            "No records found for year=%s category=%s",
+            year, category,
+        )
+
+    logger.info(
+        "Crawled %d judgment records (year=%s, category=%s)",
+        len(records), year, category,
+    )
+    return records
+
+
+async def crawl_all_years() -> list[JudgmentRecord]:
+    """Crawl all reported judgments (all years, all categories)."""
+    return await crawl_judgments(year=None, category=None)
+
+
+async def crawl_by_year(year: int) -> list[JudgmentRecord]:
+    """Crawl reported judgments for a specific year."""
+    return await crawl_judgments(year=year, category=None)

--- a/src/pipelines/lahore_hc/pipeline.py
+++ b/src/pipelines/lahore_hc/pipeline.py
@@ -1,0 +1,253 @@
+"""Lahore High Court crawler pipeline.
+
+Orchestrates the full flow: form search → table extraction → PDF download → text output.
+Single responsibility: coordinate the pipeline stages with crash resilience.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+
+from src.extractors.common.pdf_extract import download_and_extract
+
+from .constants import COURT_CODE
+from .listing import JudgmentRecord, crawl_judgments
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OUTPUT_DIR = Path(
+    os.environ.get("LHC_OUTPUT_DIR", "data/lahore_hc")
+)
+
+CHECKPOINT_INTERVAL = 25
+
+
+async def crawl_full(
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    limit: int | None = None,
+    year: int | None = None,
+    category: str | None = None,
+) -> list[dict]:
+    """Crawl LHC reported judgments and extract PDF text.
+
+    Args:
+        output_dir: Directory to save results and PDFs.
+        limit: Max number of judgments to process. None for all.
+        year: Filter by year. None for all years.
+        category: Filter by category. None for all.
+
+    Returns:
+        List of result dicts with metadata + extracted text.
+
+    Raises:
+        CrawlError: If the listing page cannot be crawled.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    pdf_dir = output_dir / "pdfs"
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+
+    # Stage 1: Get judgment records from the search table
+    logger.info("Stage 1: Crawling judgment listings (year=%s, category=%s)...", year, category)
+    records = await crawl_judgments(year=year, category=category)
+    logger.info("Found %d judgment records", len(records))
+
+    if limit:
+        records = records[:limit]
+        logger.info("Limited to %d records", limit)
+
+    # Stage 2: Download PDFs and extract text
+    results = await _process_records(records, pdf_dir)
+
+    # Save results
+    _save_results(results, output_dir / "results.jsonl")
+    _save_summary(results, output_dir / "summary.json")
+    return results
+
+
+async def crawl_year(
+    year: int,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    limit: int | None = None,
+) -> list[dict]:
+    """Crawl a single year of LHC judgments."""
+    return await crawl_full(output_dir=output_dir, limit=limit, year=year)
+
+
+async def _process_records(
+    records: list[JudgmentRecord],
+    pdf_dir: Path,
+) -> list[dict]:
+    """Download PDFs and extract text for each judgment record.
+
+    Per-record error isolation so one failure doesn't kill the batch.
+    Checkpoint saves every CHECKPOINT_INTERVAL records.
+    """
+    results: list[dict] = []
+    seen_urls: set[str] = set()
+    checkpoint_path = pdf_dir.parent / "checkpoint.jsonl"
+    failed_count = 0
+
+    for idx, record in enumerate(records):
+        # Deduplicate by PDF URL
+        if record.pdf_url and record.pdf_url in seen_urls:
+            logger.debug("Skipping duplicate PDF: %s", record.pdf_url)
+            continue
+        if record.pdf_url:
+            seen_urls.add(record.pdf_url)
+
+        try:
+            result = await _process_single_record(record, pdf_dir)
+            results.append(result)
+
+            if result["text"]:
+                logger.info(
+                    "[%d/%d] OK: %s — %d chars",
+                    idx + 1, len(records),
+                    record.case_number or "?",
+                    result["text_length"],
+                )
+            else:
+                logger.warning(
+                    "[%d/%d] EMPTY: %s — no text extracted",
+                    idx + 1, len(records),
+                    record.case_number or record.pdf_url,
+                )
+
+        except Exception as e:
+            failed_count += 1
+            logger.error(
+                "[%d/%d] FAILED: %s: %s",
+                idx + 1, len(records), record.case_number, e,
+                exc_info=True,
+            )
+            results.append({
+                **record.model_dump(),
+                "text": "",
+                "text_length": 0,
+                "error": str(e),
+                "source": "lahore_hc",
+                "court": COURT_CODE,
+            })
+
+        # Checkpoint save
+        if len(results) % CHECKPOINT_INTERVAL == 0 and results:
+            _save_results(results, checkpoint_path)
+            logger.info("Checkpoint: %d results saved", len(results))
+
+    with_text = sum(1 for r in results if r["text"])
+    logger.info(
+        "Processed %d records: %d with text, %d empty, %d failed",
+        len(results), with_text, len(results) - with_text - failed_count, failed_count,
+    )
+    return results
+
+
+async def _process_single_record(
+    record: JudgmentRecord,
+    pdf_dir: Path,
+) -> dict:
+    """Download PDF and extract text for a single judgment record."""
+    text = ""
+    if record.pdf_url:
+        text = await download_and_extract(record.pdf_url, pdf_dir)
+    else:
+        logger.warning("No PDF URL for %s", record.case_number)
+
+    return {
+        **record.model_dump(),
+        "text": text,
+        "text_length": len(text),
+        "source": "lahore_hc",
+        "court": COURT_CODE,
+    }
+
+
+def _save_results(results: list[dict], path: Path) -> None:
+    """Save results as JSONL."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(path, "w") as f:
+            for result in results:
+                row = {}
+                for k, v in result.items():
+                    if hasattr(v, "isoformat"):
+                        row[k] = v.isoformat()
+                    else:
+                        row[k] = v
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+        logger.info("Saved %d results to %s", len(results), path)
+    except (OSError, TypeError) as e:
+        logger.error("Failed to save results to %s: %s", path, e)
+        raise
+
+
+def _save_summary(results: list[dict], path: Path) -> None:
+    """Save a summary of the crawl run."""
+    with_text = sum(1 for r in results if r.get("text"))
+    errors = sum(1 for r in results if r.get("error"))
+
+    by_category: dict[str, int] = {}
+    for r in results:
+        cat = r.get("category", "unknown")
+        by_category[cat] = by_category.get(cat, 0) + 1
+
+    summary = {
+        "total_records": len(results),
+        "with_text": with_text,
+        "empty_text": len(results) - with_text,
+        "errors": errors,
+        "by_category": by_category,
+        "records": [
+            {
+                "case_number": r.get("case_number"),
+                "category": r.get("category"),
+                "decision_date": r.get("decision_date"),
+                "text_length": r.get("text_length", 0),
+                "error": r.get("error"),
+            }
+            for r in results
+        ],
+    }
+    try:
+        with open(path, "w") as f:
+            json.dump(summary, f, indent=2, ensure_ascii=False)
+    except (OSError, TypeError) as e:
+        logger.error("Failed to save summary to %s: %s", path, e)
+
+
+async def main():
+    """CLI entry point."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Lahore High Court Judgment Crawler")
+    parser.add_argument("--year", type=int, default=None, help="Filter by year (2010-2026)")
+    parser.add_argument("--category", type=str, default=None, help="Filter by category")
+    parser.add_argument("--limit", type=int, default=None, help="Max judgments to process")
+    parser.add_argument("--output", type=str, default=str(DEFAULT_OUTPUT_DIR))
+    args = parser.parse_args()
+
+    output_dir = Path(args.output)
+
+    results = await crawl_full(
+        output_dir=output_dir,
+        limit=args.limit,
+        year=args.year,
+        category=args.category,
+    )
+
+    with_text = sum(1 for r in results if r["text"])
+    errors = sum(1 for r in results if r.get("error"))
+    logger.info("Done: %d records, %d with text, %d errors", len(results), with_text, errors)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_lahore_hc.py
+++ b/tests/test_lahore_hc.py
@@ -1,0 +1,291 @@
+"""Tests for the Lahore HC crawler pipeline.
+
+Tests parsing logic with realistic sample data based on the LHC website structure.
+Does NOT hit the live website — all tests use offline sample data.
+"""
+
+from datetime import date
+
+import pytest
+
+from src.pipelines.lahore_hc.listing import (
+    JudgmentRecord,
+    _extract_pdf_url_from_html,
+    _normalize_pdf_url,
+    _parse_date,
+    parse_css_rows,
+    parse_table_data,
+)
+
+
+class TestParseDate:
+    def test_standard_date_dashes(self):
+        assert _parse_date("23-12-2024") == date(2024, 12, 23)
+
+    def test_standard_date_slashes(self):
+        assert _parse_date("23/12/2024") == date(2024, 12, 23)
+
+    def test_single_digit_day(self):
+        assert _parse_date("5-01-2023") == date(2023, 1, 5)
+
+    def test_empty(self):
+        assert _parse_date("") is None
+
+    def test_invalid(self):
+        assert _parse_date("not-a-date") is None
+
+    def test_whitespace(self):
+        assert _parse_date("  23-12-2024  ") == date(2024, 12, 23)
+
+    def test_none_like(self):
+        assert _parse_date("   ") is None
+
+
+class TestNormalizePdfUrl:
+    def test_absolute_https(self):
+        url = "https://sys.lhc.gov.pk/appjudgments/2024LHC4177.pdf"
+        assert _normalize_pdf_url(url) == url
+
+    def test_absolute_http(self):
+        url = "http://sys.lhc.gov.pk/appjudgments/2021LHC630.pdf"
+        assert _normalize_pdf_url(url) == url
+
+    def test_relative_path(self):
+        result = _normalize_pdf_url("/appjudgments/2024LHC4177.pdf")
+        assert result == "https://sys.lhc.gov.pk/appjudgments/2024LHC4177.pdf"
+
+    def test_filename_only(self):
+        result = _normalize_pdf_url("2024LHC4177.pdf")
+        assert result == "https://sys.lhc.gov.pk/appjudgments/2024LHC4177.pdf"
+
+    def test_empty(self):
+        assert _normalize_pdf_url("") == ""
+
+    def test_whitespace(self):
+        assert _normalize_pdf_url("  ") == ""
+
+    def test_non_pdf(self):
+        result = _normalize_pdf_url("some_path")
+        assert result == "some_path"
+
+
+class TestExtractPdfUrlFromHtml:
+    def test_standard_link(self):
+        html = '<a href="https://sys.lhc.gov.pk/appjudgments/2024LHC4177.pdf">View</a>'
+        result = _extract_pdf_url_from_html(html)
+        assert result == "https://sys.lhc.gov.pk/appjudgments/2024LHC4177.pdf"
+
+    def test_relative_link(self):
+        html = '<a href="/appjudgments/2021LHC630.pdf">Download</a>'
+        result = _extract_pdf_url_from_html(html)
+        assert result == "https://sys.lhc.gov.pk/appjudgments/2021LHC630.pdf"
+
+    def test_single_quotes(self):
+        html = "<a href='2024LHC100.pdf'>PDF</a>"
+        result = _extract_pdf_url_from_html(html)
+        assert result == "https://sys.lhc.gov.pk/appjudgments/2024LHC100.pdf"
+
+    def test_no_link(self):
+        assert _extract_pdf_url_from_html("No link here") == ""
+
+    def test_empty(self):
+        assert _extract_pdf_url_from_html("") == ""
+
+
+class TestParseTableData:
+    """Tests for DefaultTableExtraction output parsing."""
+
+    @pytest.fixture
+    def sample_table(self):
+        return {
+            "headers": [
+                "S.No", "Case No", "Case Title", "Judge Name",
+                "LHC Citation", "Other Citation", "Category",
+                "Decision Date", "Judgment",
+            ],
+            "rows": [
+                [
+                    "1",
+                    "W.P. No. 12345/2024",
+                    "Muhammad Ali Vs Province of Punjab",
+                    "Justice Ahmed Khan",
+                    "2024 LHC 4177",
+                    "2024 CLC 500",
+                    "Constitutional",
+                    "23-12-2024",
+                    '<a href="https://sys.lhc.gov.pk/appjudgments/2024LHC4177.pdf">View</a>',
+                ],
+                [
+                    "2",
+                    "Cr.A No. 200/2023",
+                    "State Vs Aslam Khan",
+                    "Justice Farooq Haider",
+                    "2023 LHC 630",
+                    "2023 PCrLJ 100",
+                    "Criminal",
+                    "15-06-2023",
+                    '<a href="/appjudgments/2023LHC630.pdf">View</a>',
+                ],
+            ],
+        }
+
+    def test_parses_records(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert len(records) == 2
+        assert all(isinstance(r, JudgmentRecord) for r in records)
+
+    def test_case_number_parsed(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert records[0].case_number == "W.P. No. 12345/2024"
+        assert records[1].case_number == "Cr.A No. 200/2023"
+
+    def test_case_title_parsed(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert records[0].case_title == "Muhammad Ali Vs Province of Punjab"
+
+    def test_judge_name(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert records[0].judge_name == "Justice Ahmed Khan"
+        assert records[1].judge_name == "Justice Farooq Haider"
+
+    def test_date_parsed(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert records[0].decision_date_parsed == date(2024, 12, 23)
+        assert records[0].decision_date == "23-12-2024"
+
+    def test_category(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert records[0].category == "Constitutional"
+        assert records[1].category == "Criminal"
+
+    def test_lhc_citation(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert records[0].lhc_citation == "2024 LHC 4177"
+        assert records[1].lhc_citation == "2023 LHC 630"
+
+    def test_other_citation(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert records[0].other_citation == "2024 CLC 500"
+        assert records[1].other_citation == "2023 PCrLJ 100"
+
+    def test_pdf_url_extracted(self, sample_table):
+        records = parse_table_data(sample_table, "test_source")
+        assert records[0].pdf_url == "https://sys.lhc.gov.pk/appjudgments/2024LHC4177.pdf"
+        assert records[1].pdf_url == "https://sys.lhc.gov.pk/appjudgments/2023LHC630.pdf"
+
+    def test_empty_rows(self):
+        table = {"headers": ["S.No", "Case No"], "rows": []}
+        records = parse_table_data(table, "test")
+        assert records == []
+
+    def test_source_url_set(self, sample_table):
+        records = parse_table_data(sample_table, "my_source")
+        assert all(r.source_url == "my_source" for r in records)
+
+    def test_positional_fallback(self):
+        """When headers are missing, positional access should work."""
+        table = {
+            "headers": [],
+            "rows": [
+                [
+                    "1",
+                    "W.P. No. 100/2024",
+                    "Test Vs Test",
+                    "Justice X",
+                    "2024 LHC 100",
+                    "",
+                    "Civil",
+                    "01-01-2024",
+                    "",
+                ],
+            ],
+        }
+        records = parse_table_data(table, "test")
+        assert len(records) == 1
+        assert records[0].case_number == "W.P. No. 100/2024"
+        assert records[0].category == "Civil"
+
+    def test_short_row_skipped(self):
+        """Rows with too few columns should be skipped."""
+        table = {
+            "headers": [],
+            "rows": [
+                ["1", "W.P. No. 100/2024", "Test"],
+            ],
+        }
+        records = parse_table_data(table, "test")
+        assert records == []
+
+
+class TestParseCssRows:
+    """Tests for JsonCssExtractionStrategy output parsing."""
+
+    @pytest.fixture
+    def sample_rows(self):
+        return [
+            {
+                "serial": "1",
+                "case_number": "W.P. No. 12345/2024",
+                "case_title": "Muhammad Ali Vs Province of Punjab",
+                "judge_name": "Justice Ahmed Khan",
+                "lhc_citation": "2024 LHC 4177",
+                "other_citation": "2024 CLC 500",
+                "category": "Constitutional",
+                "decision_date": "23-12-2024",
+                "pdf_url": "https://sys.lhc.gov.pk/appjudgments/2024LHC4177.pdf",
+            },
+            {
+                "serial": "2",
+                "case_number": "Cr.A No. 200/2023",
+                "case_title": "State Vs Aslam Khan",
+                "judge_name": "Justice Farooq Haider",
+                "lhc_citation": "2023 LHC 630",
+                "other_citation": "2023 PCrLJ 100",
+                "category": "Criminal",
+                "decision_date": "15/06/2023",
+                "pdf_url": "/appjudgments/2023LHC630.pdf",
+            },
+        ]
+
+    def test_parses_records(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source")
+        assert len(records) == 2
+        assert all(isinstance(r, JudgmentRecord) for r in records)
+
+    def test_pdf_urls_normalized(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source")
+        assert records[0].pdf_url == "https://sys.lhc.gov.pk/appjudgments/2024LHC4177.pdf"
+        assert records[1].pdf_url == "https://sys.lhc.gov.pk/appjudgments/2023LHC630.pdf"
+
+    def test_case_number_parsed(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source")
+        assert records[0].case_number == "W.P. No. 12345/2024"
+        assert records[1].case_number == "Cr.A No. 200/2023"
+
+    def test_judge_name(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source")
+        assert records[0].judge_name == "Justice Ahmed Khan"
+
+    def test_date_parsed_slash_format(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source")
+        assert records[1].decision_date_parsed == date(2023, 6, 15)
+
+    def test_criminal_category(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source")
+        assert records[1].category == "Criminal"
+
+    def test_empty_list(self):
+        records = parse_css_rows([], "test")
+        assert records == []
+
+    def test_missing_fields(self):
+        rows = [{"serial": "1", "case_number": "W.P. No. 100/2024"}]
+        records = parse_css_rows(rows, "test")
+        assert len(records) == 1
+        assert records[0].pdf_url == ""
+        assert records[0].category == ""
+        assert records[0].judge_name == ""
+
+    def test_lhc_citation(self, sample_rows):
+        records = parse_css_rows(sample_rows, "test_source")
+        assert records[0].lhc_citation == "2024 LHC 4177"


### PR DESCRIPTION
## Summary
- crawl4ai pipeline for LHC via data.lhc.gov.pk
- Form submission + DataTable extraction (similar to PHC pattern)
- ~4,078 reported judgments, PDFs at sys.lhc.gov.pk
- Site geo-blocked by FortiGuard IPS (needs Pakistani IP/VPN for live use)
- 41 offline tests

## Site Status
- data.lhc.gov.pk blocked by FortiGuard from non-Pakistani IPs
- Pipeline correctly raises CrawlError with ERR_CONNECTION_TIMED_OUT
- Needs VPN or Pakistani server for live validation

## Test plan
- [x] 41 offline unit tests pass
- [ ] Live validation pending Pakistani IP access

Ref #2