### PR TITLE
Add Federal Shariat Court crawler pipeline (#7)

### DIFF
--- a/src/pipelines/federal_shariat/constants.py
+++ b/src/pipelines/federal_shariat/constants.py
@@ -1,0 +1,39 @@
+"""Shared constants for the Federal Shariat Court crawler pipeline."""
+
+BASE_URL = "https://www.federalshariatcourt.gov.pk"
+
+# New WordPress-style site structure (post-redesign)
+HOME_URL = f"{BASE_URL}/en/home/"
+JUDGMENTS_URL = f"{BASE_URL}/en/judgments/"
+LEADING_JUDGMENTS_URL = f"{BASE_URL}/en/leading-judgements/"
+
+# Legacy PDF base path (PDFs still served from old path)
+PDF_BASE_URL = f"{BASE_URL}/Judgments/"
+
+# FSC case type prefixes discovered via recon
+# Criminal Appeals, Shariat Petitions, Criminal Revisions, Jail Criminal Appeals
+CASE_TYPE_PREFIXES = [
+    "Cr.App",       # Criminal Appeal
+    "Cr.A",         # Criminal Appeal (alternate)
+    "J.Cr.A",       # Jail Criminal Appeal
+    "Cr.Rev",       # Criminal Revision
+    "Cr.M",         # Criminal Miscellaneous
+    "Sh.P",         # Shariat Petition
+    "S.P",          # Shariat Petition (alternate)
+    "R.Sr.P",       # Review Shariat Petition
+    "W.P",          # Writ Petition
+]
+
+# Branch codes used in case numbers (court circuit identifiers)
+BRANCH_CODES = [
+    "I",    # Islamabad
+    "L",    # Lahore
+    "K",    # Karachi
+    "Q",    # Quetta
+    "P",    # Peshawar
+    "D",    # D.I. Khan
+    "M",    # Mardan / Mingora
+]
+
+# Court code used in Qdrant point IDs
+COURT_CODE = "FSC"

--- a/src/pipelines/federal_shariat/errors.py
+++ b/src/pipelines/federal_shariat/errors.py
@@ -1,0 +1,9 @@
+"""Custom exceptions for the Federal Shariat Court crawler pipeline."""
+
+
+class CrawlError(Exception):
+    """Raised when a crawl operation fails irrecoverably."""
+
+
+class ExtractionError(Exception):
+    """Raised when data extraction from HTML/PDF fails."""

--- a/src/pipelines/federal_shariat/listing.py
+++ b/src/pipelines/federal_shariat/listing.py
@@ -1,0 +1,460 @@
+"""Crawl Federal Shariat Court judgments and extract case metadata.
+
+Single responsibility: page load + HTML extraction → list of JudgmentRecord.
+
+The FSC website (post-redesign) has two judgment pages:
+1. /en/leading-judgements/ — curated table with S.No, Title/Reference, Date, Download link
+2. /en/judgments/ — search form (case number, party name, judge)
+
+The leading judgments page is a static table (no DataTable/AJAX), making it the
+more reliable extraction target. The search page requires form interaction.
+
+Table columns on /en/leading-judgements/:
+  0: S.No
+  1: Title Reference with Date of Decision
+  2: Download Judgment (PDF link)
+
+PDF URL pattern: /Judgments/{case-file-name}.pdf
+Case number pattern: "Cr.App.No.15.I.of.2018" or "Shariat Petition No. 10-I of 2023"
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from datetime import date
+
+from pydantic import BaseModel
+
+from .constants import BASE_URL, JUDGMENTS_URL, LEADING_JUDGMENTS_URL
+from .errors import CrawlError
+
+logger = logging.getLogger(__name__)
+
+
+class JudgmentRecord(BaseModel):
+    """A single judgment record extracted from the FSC website."""
+
+    serial: int
+    case_number: str
+    case_title: str
+    case_type: str
+    decision_date: str
+    decision_date_parsed: date | None = None
+    pdf_url: str
+    source_url: str
+
+
+def _parse_date(raw: str) -> date | None:
+    """Parse various date formats found in FSC records.
+
+    Handles:
+    - dd.mm.yyyy (e.g., "19.03.2025")
+    - dd-mm-yyyy (e.g., "19-03-2025")
+    - dd/mm/yyyy (e.g., "19/03/2025")
+    """
+    raw = raw.strip()
+    if not raw:
+        return None
+    try:
+        # Normalize separators
+        normalized = raw.replace("/", "-").replace(".", "-")
+        parts = normalized.split("-")
+        if len(parts) == 3:
+            day, month, year = int(parts[0]), int(parts[1]), int(parts[2])
+            # Handle 2-digit years
+            if year < 100:
+                year += 1900 if year > 50 else 2000
+            return date(year, month, day)
+    except (ValueError, IndexError):
+        pass
+    logger.debug("Could not parse date: %s", raw)
+    return None
+
+
+def _extract_date_from_title(title: str) -> str:
+    """Extract date string from title text.
+
+    FSC titles often include the date like:
+    "... dated 19.03.2025" or "Decision Date: 19-03-2025"
+    or just a date at the end in parentheses "(19.03.2025)"
+    """
+    # Pattern: "dated DD.MM.YYYY" or "dated DD-MM-YYYY"
+    match = re.search(
+        r"(?:dated|decision\s+date[:\s]*)\s*(\d{1,2}[./-]\d{1,2}[./-]\d{2,4})",
+        title,
+        re.IGNORECASE,
+    )
+    if match:
+        return match.group(1)
+
+    # Pattern: date in parentheses at end
+    match = re.search(r"\((\d{1,2}[./-]\d{1,2}[./-]\d{2,4})\)\s*$", title)
+    if match:
+        return match.group(1)
+
+    # Pattern: standalone date (DD.MM.YYYY) anywhere
+    match = re.search(r"(\d{1,2}[./-]\d{1,2}[./-]\d{4})", title)
+    if match:
+        return match.group(1)
+
+    return ""
+
+
+def _extract_case_number(title: str) -> str:
+    """Extract case number from the title text.
+
+    Examples:
+    - "Shariat Petition No. 10-I of 2023" → "Shariat Petition No. 10-I of 2023"
+    - "Cr.App.No.15.I.of.2018" → "Cr.App.No.15.I.of.2018"
+    - "Criminal Appeal No. 23 - Q - of 2005" → "Criminal Appeal No. 23 - Q - of 2005"
+    """
+    # Pattern: Various case number formats with "No." and "of YYYY"
+    match = re.search(
+        r"((?:Cr\.?\s*(?:App|Rev|M)|J\.?Cr\.?A|Sh\.?P|S\.?P|R\.?Sr\.?P|W\.?P|"
+        r"Shariat\s+Petition|Criminal\s+(?:Appeal|Revision|Miscellaneous)|"
+        r"Jail\s+Criminal\s+Appeal|Review\s+Shariat\s+Petition|"
+        r"Writ\s+Petition)"
+        r"[.\s]*No\.?\s*[\d]+[\s.\-]*[A-Z]?[\s.\-]*(?:of|OF)\s*\d{4})",
+        title,
+        re.IGNORECASE,
+    )
+    if match:
+        return match.group(1).strip()
+
+    # Simpler pattern: "No. X-Y of YYYY"
+    match = re.search(
+        r"([\w.\s]+No\.?\s*[\d]+[\s\-]*[\w]*[\s\-]*(?:of|OF)\s*\d{4})",
+        title,
+    )
+    if match:
+        return match.group(1).strip()
+
+    return title.strip()
+
+
+def _classify_case_type(case_number: str) -> str:
+    """Classify the case type from the case number prefix."""
+    lower = case_number.lower()
+    if "shariat petition" in lower or "sh.p" in lower or "s.p" in lower:
+        if "review" in lower or "r.sr.p" in lower:
+            return "Review Shariat Petition"
+        return "Shariat Petition"
+    if "jail" in lower or "j.cr" in lower:
+        return "Jail Criminal Appeal"
+    if "cr.app" in lower or "criminal appeal" in lower or "cr.a" in lower:
+        return "Criminal Appeal"
+    if "cr.rev" in lower or "criminal revision" in lower:
+        return "Criminal Revision"
+    if "cr.m" in lower or "criminal miscellaneous" in lower:
+        return "Criminal Miscellaneous"
+    if "w.p" in lower or "writ petition" in lower:
+        return "Writ Petition"
+    return "Other"
+
+
+def _normalize_pdf_url(raw_url: str) -> str:
+    """Normalize a PDF URL to absolute form."""
+    raw_url = raw_url.strip()
+    if not raw_url:
+        return ""
+    if raw_url.startswith("http"):
+        return raw_url
+    if raw_url.startswith("/"):
+        return BASE_URL + raw_url
+    return BASE_URL + "/" + raw_url
+
+
+def parse_leading_judgments_rows(
+    raw_rows: list[dict],
+    source_url: str,
+) -> list[JudgmentRecord]:
+    """Parse rows from JsonCssExtractionStrategy for the leading judgments page."""
+    records = []
+    for row in raw_rows:
+        title = row.get("title", "").strip()
+        if not title:
+            continue
+
+        case_number = _extract_case_number(title)
+        case_type = _classify_case_type(case_number)
+        date_str = _extract_date_from_title(title)
+        pdf_url = _normalize_pdf_url(row.get("pdf_url", ""))
+
+        # Case title is the full title text minus the case number
+        case_title = title.replace(case_number, "").strip(" -–—().,")
+
+        record = JudgmentRecord(
+            serial=int(row.get("serial", 0) or 0),
+            case_number=case_number,
+            case_title=case_title if case_title else title,
+            case_type=case_type,
+            decision_date=date_str,
+            decision_date_parsed=_parse_date(date_str),
+            pdf_url=pdf_url,
+            source_url=source_url,
+        )
+        records.append(record)
+
+    return records
+
+
+def parse_judgment_search_rows(
+    raw_rows: list[dict],
+    source_url: str,
+) -> list[JudgmentRecord]:
+    """Parse rows from the judgment search results page."""
+    records = []
+    for row in raw_rows:
+        case_number = row.get("case_number", "").strip()
+        title = row.get("title", "").strip()
+        date_str = row.get("decision_date", "").strip()
+        pdf_url = _normalize_pdf_url(row.get("pdf_url", ""))
+
+        if not case_number and not title:
+            continue
+
+        if not case_number:
+            case_number = _extract_case_number(title)
+
+        case_type = _classify_case_type(case_number)
+
+        record = JudgmentRecord(
+            serial=int(row.get("serial", 0) or 0),
+            case_number=case_number,
+            case_title=title,
+            case_type=case_type,
+            decision_date=date_str,
+            decision_date_parsed=_parse_date(date_str),
+            pdf_url=pdf_url,
+            source_url=source_url,
+        )
+        records.append(record)
+
+    return records
+
+
+# JsonCssExtractionStrategy schema for the FSC leading judgments table.
+# The table has 3 columns: S.No, Title/Reference with Date, Download link.
+CSS_LEADING_JUDGMENTS_SCHEMA = {
+    "name": "FSC Leading Judgments",
+    "baseSelector": "table tbody tr",
+    "fields": [
+        {"name": "serial", "selector": "td:nth-child(1)", "type": "text"},
+        {"name": "title", "selector": "td:nth-child(2)", "type": "text"},
+        {
+            "name": "pdf_url",
+            "selector": "td:nth-child(3) a, td:nth-child(2) a",
+            "type": "attribute",
+            "attribute": "href",
+        },
+    ],
+}
+
+# Schema for the judgment search results page.
+# Structure may vary — this is a best-effort schema based on recon.
+CSS_JUDGMENT_SEARCH_SCHEMA = {
+    "name": "FSC Judgment Search Results",
+    "baseSelector": "table tbody tr",
+    "fields": [
+        {"name": "serial", "selector": "td:nth-child(1)", "type": "text"},
+        {"name": "case_number", "selector": "td:nth-child(2)", "type": "text"},
+        {"name": "title", "selector": "td:nth-child(3)", "type": "text"},
+        {"name": "decision_date", "selector": "td:nth-child(4)", "type": "text"},
+        {
+            "name": "pdf_url",
+            "selector": "td a[href*='.pdf'], td a[href*='Judgment']",
+            "type": "attribute",
+            "attribute": "href",
+        },
+    ],
+}
+
+
+async def crawl_leading_judgments() -> list[JudgmentRecord]:
+    """Crawl the FSC leading judgments page.
+
+    The leading judgments page is a static table (no AJAX/DataTable),
+    so a single page load + CSS extraction suffices.
+
+    Returns:
+        List of JudgmentRecord extracted from the leading judgments table.
+
+    Raises:
+        CrawlError: If the page cannot be loaded or extraction fails.
+    """
+    from crawl4ai import (
+        AsyncWebCrawler,
+        BrowserConfig,
+        CacheMode,
+        CrawlerRunConfig,
+        JsonCssExtractionStrategy,
+    )
+
+    browser_config = BrowserConfig(
+        headless=True,
+        extra_args=["--ignore-certificate-errors"],
+    )
+
+    extraction_strategy = JsonCssExtractionStrategy(
+        schema=CSS_LEADING_JUDGMENTS_SCHEMA, verbose=False,
+    )
+
+    config = CrawlerRunConfig(
+        cache_mode=CacheMode.BYPASS,
+        wait_until="networkidle",
+        delay_before_return_html=3.0,
+        page_timeout=90000,
+        extraction_strategy=extraction_strategy,
+    )
+
+    async with AsyncWebCrawler(config=browser_config) as crawler:
+        result = await crawler.arun(url=LEADING_JUDGMENTS_URL, config=config)
+
+        if not result.success:
+            raise CrawlError(
+                f"Failed to load leading judgments page: {result.error_message}"
+            )
+
+        records = []
+        if result.extracted_content:
+            try:
+                raw_rows = json.loads(result.extracted_content)
+                records = parse_leading_judgments_rows(
+                    raw_rows, LEADING_JUDGMENTS_URL,
+                )
+            except json.JSONDecodeError as e:
+                raise CrawlError(
+                    f"Failed to parse extracted JSON: {e}"
+                ) from e
+
+    if not records:
+        logger.warning("No records found on leading judgments page")
+
+    logger.info("Crawled %d leading judgment records", len(records))
+    return records
+
+
+async def crawl_judgment_search(
+    case_number: str | None = None,
+    party_name: str | None = None,
+    judge_name: str | None = None,
+) -> list[JudgmentRecord]:
+    """Crawl the FSC judgment search page by submitting search criteria.
+
+    The search page accepts case number, party name, or judge name.
+    Uses a two-step crawl4ai session approach:
+    1. Load search page and submit form with search criteria.
+    2. Extract results from the response table.
+
+    Args:
+        case_number: Search by case number.
+        party_name: Search by party name.
+        judge_name: Search by judge name.
+
+    Returns:
+        List of JudgmentRecord extracted from search results.
+
+    Raises:
+        CrawlError: If the page cannot be loaded or extraction fails.
+    """
+    from crawl4ai import (
+        AsyncWebCrawler,
+        BrowserConfig,
+        CacheMode,
+        CrawlerRunConfig,
+        JsonCssExtractionStrategy,
+    )
+
+    browser_config = BrowserConfig(
+        headless=True,
+        extra_args=["--ignore-certificate-errors"],
+    )
+
+    # Build form submission JavaScript
+    fill_parts = []
+    if case_number:
+        fill_parts.append(
+            f"const caseInput = document.querySelector('input[name*=\"case\"], "
+            f"input[placeholder*=\"case\" i]');"
+            f"if (caseInput) caseInput.value = '{case_number}';"
+        )
+    if party_name:
+        fill_parts.append(
+            f"const partyInput = document.querySelector('input[name*=\"party\"], "
+            f"input[placeholder*=\"party\" i]');"
+            f"if (partyInput) partyInput.value = '{party_name}';"
+        )
+    if judge_name:
+        fill_parts.append(
+            f"const judgeInput = document.querySelector('input[name*=\"judge\"], "
+            f"select[name*=\"judge\"]');"
+            f"if (judgeInput) judgeInput.value = '{judge_name}';"
+        )
+    fill_parts.append(
+        "const submitBtn = document.querySelector("
+        "'input[type=\"submit\"], button[type=\"submit\"]');"
+        "if (submitBtn) submitBtn.click();"
+    )
+    submit_js = "\n".join(fill_parts)
+
+    extraction_strategy = JsonCssExtractionStrategy(
+        schema=CSS_JUDGMENT_SEARCH_SCHEMA, verbose=False,
+    )
+
+    session_id = "fsc_search_session"
+
+    async with AsyncWebCrawler(config=browser_config) as crawler:
+        # Step 1: Load search page and submit form
+        step1_config = CrawlerRunConfig(
+            session_id=session_id,
+            cache_mode=CacheMode.BYPASS,
+            wait_until="networkidle",
+            js_code=submit_js,
+            delay_before_return_html=5.0,
+            page_timeout=90000,
+        )
+        result = await crawler.arun(url=JUDGMENTS_URL, config=step1_config)
+        if not result.success:
+            raise CrawlError(
+                f"Search form submission failed: {result.error_message}"
+            )
+
+        # Step 2: Extract results from the loaded page
+        step2_config = CrawlerRunConfig(
+            session_id=session_id,
+            cache_mode=CacheMode.BYPASS,
+            js_only=True,
+            delay_before_return_html=2.0,
+            extraction_strategy=extraction_strategy,
+            page_timeout=30000,
+        )
+        result = await crawler.arun(url=JUDGMENTS_URL, config=step2_config)
+
+        if not result.success:
+            raise CrawlError(
+                f"Search result extraction failed: {result.error_message}"
+            )
+
+        records = []
+        if result.extracted_content:
+            try:
+                raw_rows = json.loads(result.extracted_content)
+                records = parse_judgment_search_rows(raw_rows, JUDGMENTS_URL)
+            except json.JSONDecodeError as e:
+                raise CrawlError(
+                    f"Failed to parse extracted JSON: {e}"
+                ) from e
+
+    if not records:
+        logger.warning(
+            "No records found for case_number=%s party=%s judge=%s",
+            case_number, party_name, judge_name,
+        )
+
+    logger.info(
+        "Crawled %d judgment records (case=%s, party=%s, judge=%s)",
+        len(records), case_number, party_name, judge_name,
+    )
+    return records

--- a/src/pipelines/federal_shariat/pipeline.py
+++ b/src/pipelines/federal_shariat/pipeline.py
@@ -1,0 +1,271 @@
+"""Federal Shariat Court crawler pipeline.
+
+Orchestrates the full flow: page crawl → table extraction → PDF download → text output.
+Single responsibility: coordinate the pipeline stages with crash resilience.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+
+from src.extractors.common.pdf_extract import download_and_extract
+
+from .constants import COURT_CODE
+from .listing import JudgmentRecord, crawl_leading_judgments, crawl_judgment_search
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_OUTPUT_DIR = Path(
+    os.environ.get("FSC_OUTPUT_DIR", "data/federal_shariat")
+)
+
+CHECKPOINT_INTERVAL = 25
+
+
+async def crawl_full(
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    limit: int | None = None,
+    source: str = "leading",
+    case_number: str | None = None,
+    party_name: str | None = None,
+    judge_name: str | None = None,
+) -> list[dict]:
+    """Crawl FSC judgments and extract PDF text.
+
+    Args:
+        output_dir: Directory to save results and PDFs.
+        limit: Max number of judgments to process. None for all.
+        source: "leading" for leading judgments page, "search" for search form.
+        case_number: Search filter (only for source="search").
+        party_name: Search filter (only for source="search").
+        judge_name: Search filter (only for source="search").
+
+    Returns:
+        List of result dicts with metadata + extracted text.
+
+    Raises:
+        CrawlError: If the listing page cannot be crawled.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    pdf_dir = output_dir / "pdfs"
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+
+    # Stage 1: Get judgment records
+    if source == "search":
+        logger.info(
+            "Stage 1: Searching judgments (case=%s, party=%s, judge=%s)...",
+            case_number, party_name, judge_name,
+        )
+        records = await crawl_judgment_search(
+            case_number=case_number,
+            party_name=party_name,
+            judge_name=judge_name,
+        )
+    else:
+        logger.info("Stage 1: Crawling leading judgments page...")
+        records = await crawl_leading_judgments()
+
+    logger.info("Found %d judgment records", len(records))
+
+    if limit:
+        records = records[:limit]
+        logger.info("Limited to %d records", limit)
+
+    # Stage 2: Download PDFs and extract text
+    results = await _process_records(records, pdf_dir)
+
+    # Save results
+    _save_results(results, output_dir / "results.jsonl")
+    _save_summary(results, output_dir / "summary.json")
+    return results
+
+
+async def _process_records(
+    records: list[JudgmentRecord],
+    pdf_dir: Path,
+) -> list[dict]:
+    """Download PDFs and extract text for each judgment record.
+
+    Per-record error isolation so one failure doesn't kill the batch.
+    Checkpoint saves every CHECKPOINT_INTERVAL records.
+    """
+    results: list[dict] = []
+    seen_urls: set[str] = set()
+    checkpoint_path = pdf_dir.parent / "checkpoint.jsonl"
+    failed_count = 0
+
+    for idx, record in enumerate(records):
+        # Deduplicate by PDF URL
+        if record.pdf_url and record.pdf_url in seen_urls:
+            logger.debug("Skipping duplicate PDF: %s", record.pdf_url)
+            continue
+        if record.pdf_url:
+            seen_urls.add(record.pdf_url)
+
+        try:
+            result = await _process_single_record(record, pdf_dir)
+            results.append(result)
+
+            if result["text"]:
+                logger.info(
+                    "[%d/%d] OK: %s — %d chars",
+                    idx + 1, len(records),
+                    record.case_number or "?",
+                    result["text_length"],
+                )
+            else:
+                logger.warning(
+                    "[%d/%d] EMPTY: %s — no text extracted",
+                    idx + 1, len(records),
+                    record.case_number or record.pdf_url,
+                )
+
+        except Exception as e:
+            failed_count += 1
+            logger.error(
+                "[%d/%d] FAILED: %s: %s",
+                idx + 1, len(records), record.case_number, e,
+                exc_info=True,
+            )
+            results.append({
+                **record.model_dump(),
+                "text": "",
+                "text_length": 0,
+                "error": str(e),
+                "source": "federal_shariat",
+                "court": COURT_CODE,
+            })
+
+        # Checkpoint save
+        if len(results) % CHECKPOINT_INTERVAL == 0 and results:
+            _save_results(results, checkpoint_path)
+            logger.info("Checkpoint: %d results saved", len(results))
+
+    with_text = sum(1 for r in results if r["text"])
+    logger.info(
+        "Processed %d records: %d with text, %d empty, %d failed",
+        len(results), with_text, len(results) - with_text - failed_count, failed_count,
+    )
+    return results
+
+
+async def _process_single_record(
+    record: JudgmentRecord,
+    pdf_dir: Path,
+) -> dict:
+    """Download PDF and extract text for a single judgment record."""
+    text = ""
+    if record.pdf_url:
+        text = await download_and_extract(record.pdf_url, pdf_dir)
+    else:
+        logger.warning("No PDF URL for %s", record.case_number)
+
+    return {
+        **record.model_dump(),
+        "text": text,
+        "text_length": len(text),
+        "source": "federal_shariat",
+        "court": COURT_CODE,
+    }
+
+
+def _save_results(results: list[dict], path: Path) -> None:
+    """Save results as JSONL."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(path, "w") as f:
+            for result in results:
+                # Convert date objects to strings for JSON serialization
+                row = {}
+                for k, v in result.items():
+                    if hasattr(v, "isoformat"):
+                        row[k] = v.isoformat()
+                    else:
+                        row[k] = v
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+        logger.info("Saved %d results to %s", len(results), path)
+    except (OSError, TypeError) as e:
+        logger.error("Failed to save results to %s: %s", path, e)
+        raise
+
+
+def _save_summary(results: list[dict], path: Path) -> None:
+    """Save a summary of the crawl run."""
+    with_text = sum(1 for r in results if r.get("text"))
+    errors = sum(1 for r in results if r.get("error"))
+
+    by_case_type: dict[str, int] = {}
+    for r in results:
+        ct = r.get("case_type", "unknown")
+        by_case_type[ct] = by_case_type.get(ct, 0) + 1
+
+    summary = {
+        "total_records": len(results),
+        "with_text": with_text,
+        "empty_text": len(results) - with_text,
+        "errors": errors,
+        "by_case_type": by_case_type,
+        "records": [
+            {
+                "case_number": r.get("case_number"),
+                "case_type": r.get("case_type"),
+                "decision_date": r.get("decision_date"),
+                "text_length": r.get("text_length", 0),
+                "error": r.get("error"),
+            }
+            for r in results
+        ],
+    }
+    try:
+        with open(path, "w") as f:
+            json.dump(summary, f, indent=2, ensure_ascii=False)
+    except (OSError, TypeError) as e:
+        logger.error("Failed to save summary to %s: %s", path, e)
+
+
+async def main():
+    """CLI entry point."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Federal Shariat Court Judgment Crawler",
+    )
+    parser.add_argument(
+        "--source", type=str, default="leading",
+        choices=["leading", "search"],
+        help="Data source: 'leading' for curated page, 'search' for search form",
+    )
+    parser.add_argument("--case-number", type=str, default=None, help="Search by case number")
+    parser.add_argument("--party-name", type=str, default=None, help="Search by party name")
+    parser.add_argument("--judge-name", type=str, default=None, help="Search by judge name")
+    parser.add_argument("--limit", type=int, default=None, help="Max judgments to process")
+    parser.add_argument("--output", type=str, default=str(DEFAULT_OUTPUT_DIR))
+    args = parser.parse_args()
+
+    output_dir = Path(args.output)
+
+    results = await crawl_full(
+        output_dir=output_dir,
+        limit=args.limit,
+        source=args.source,
+        case_number=args.case_number,
+        party_name=args.party_name,
+        judge_name=args.judge_name,
+    )
+
+    with_text = sum(1 for r in results if r["text"])
+    errors = sum(1 for r in results if r.get("error"))
+    logger.info("Done: %d records, %d with text, %d errors", len(results), with_text, errors)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_federal_shariat.py
+++ b/tests/test_federal_shariat.py
@@ -1,0 +1,294 @@
+"""Tests for the Federal Shariat Court crawler pipeline.
+
+Tests parsing logic with realistic sample data based on FSC website recon.
+Does NOT hit the live website — all tests use offline sample data.
+"""
+
+from datetime import date
+
+import pytest
+
+from src.pipelines.federal_shariat.constants import BASE_URL, COURT_CODE
+from src.pipelines.federal_shariat.listing import (
+    JudgmentRecord,
+    _classify_case_type,
+    _extract_case_number,
+    _extract_date_from_title,
+    _normalize_pdf_url,
+    _parse_date,
+    parse_leading_judgments_rows,
+    parse_judgment_search_rows,
+)
+
+
+class TestParseDate:
+    def test_dot_separated(self):
+        assert _parse_date("19.03.2025") == date(2025, 3, 19)
+
+    def test_dash_separated(self):
+        assert _parse_date("23-12-2024") == date(2024, 12, 23)
+
+    def test_slash_separated(self):
+        assert _parse_date("05/01/2023") == date(2023, 1, 5)
+
+    def test_single_digit_day(self):
+        assert _parse_date("5.01.2023") == date(2023, 1, 5)
+
+    def test_empty(self):
+        assert _parse_date("") is None
+
+    def test_invalid(self):
+        assert _parse_date("not-a-date") is None
+
+    def test_whitespace(self):
+        assert _parse_date("  19.03.2025  ") == date(2025, 3, 19)
+
+    def test_two_digit_year_old(self):
+        assert _parse_date("15.06.85") == date(1985, 6, 15)
+
+    def test_two_digit_year_new(self):
+        assert _parse_date("15.06.25") == date(2025, 6, 15)
+
+
+class TestExtractDateFromTitle:
+    def test_dated_format(self):
+        title = "Judgement on Chaddar or Parchi (Shariat Petition No. 10-I of 2023) dated 19.03.2025"
+        assert _extract_date_from_title(title) == "19.03.2025"
+
+    def test_parenthesized_date(self):
+        title = "Criminal Appeal No. 15-I of 2018 (23.12.2024)"
+        assert _extract_date_from_title(title) == "23.12.2024"
+
+    def test_decision_date_label(self):
+        title = "Some case Decision Date: 15-06-2024"
+        assert _extract_date_from_title(title) == "15-06-2024"
+
+    def test_standalone_date(self):
+        title = "Cr.App.No.15.I.of.2018 some text 01.02.2020"
+        assert _extract_date_from_title(title) == "01.02.2020"
+
+    def test_no_date(self):
+        title = "Some case without any date"
+        assert _extract_date_from_title(title) == ""
+
+
+class TestExtractCaseNumber:
+    def test_shariat_petition(self):
+        title = "Judgement on Chaddar or Parchi (Shariat Petition No. 10-I of 2023)"
+        result = _extract_case_number(title)
+        assert "Shariat Petition" in result
+        assert "10-I" in result
+        assert "2023" in result
+
+    def test_criminal_appeal_full(self):
+        title = "Criminal Appeal No. 23 - Q - of 2005 regarding murder"
+        result = _extract_case_number(title)
+        assert "Criminal Appeal" in result
+        assert "2005" in result
+
+    def test_abbreviated_cr_app(self):
+        title = "Cr.App.No.15.I.of.2018 State vs Accused"
+        result = _extract_case_number(title)
+        assert "Cr.App" in result
+        assert "2018" in result
+
+    def test_criminal_revision(self):
+        title = "Criminal Revision No. 01-K of 2021 Sadam Hussain"
+        result = _extract_case_number(title)
+        assert "Criminal Revision" in result
+        assert "2021" in result
+
+    def test_jail_criminal_appeal(self):
+        title = "Jail Criminal Appeal No. 34-K of 1998"
+        result = _extract_case_number(title)
+        assert "Jail Criminal Appeal" in result
+        assert "1998" in result
+
+    def test_no_match_returns_title(self):
+        title = "Some random text"
+        assert _extract_case_number(title) == "Some random text"
+
+
+class TestClassifyCaseType:
+    def test_shariat_petition(self):
+        assert _classify_case_type("Shariat Petition No. 10-I of 2023") == "Shariat Petition"
+
+    def test_shariat_petition_abbrev(self):
+        assert _classify_case_type("Sh.P.No.17 I of 1984") == "Shariat Petition"
+
+    def test_review_shariat_petition(self):
+        assert _classify_case_type("Review Shariat Petition No. 5-I of 2020") == "Review Shariat Petition"
+
+    def test_criminal_appeal(self):
+        assert _classify_case_type("Criminal Appeal No. 23-Q of 2005") == "Criminal Appeal"
+
+    def test_criminal_appeal_abbrev(self):
+        assert _classify_case_type("Cr.App.No.15.I.of.2018") == "Criminal Appeal"
+
+    def test_jail_criminal_appeal(self):
+        assert _classify_case_type("Jail Criminal Appeal No. 34-K of 1998") == "Jail Criminal Appeal"
+
+    def test_criminal_revision(self):
+        assert _classify_case_type("Criminal Revision No. 01-K of 2021") == "Criminal Revision"
+
+    def test_writ_petition(self):
+        assert _classify_case_type("W.P No. 100-I of 2022") == "Writ Petition"
+
+    def test_other(self):
+        assert _classify_case_type("Something else") == "Other"
+
+
+class TestNormalizePdfUrl:
+    def test_absolute_url(self):
+        url = "https://www.federalshariatcourt.gov.pk/Judgments/test.pdf"
+        assert _normalize_pdf_url(url) == url
+
+    def test_relative_with_slash(self):
+        url = "/Judgments/test.pdf"
+        assert _normalize_pdf_url(url) == f"{BASE_URL}/Judgments/test.pdf"
+
+    def test_relative_without_slash(self):
+        url = "Judgments/test.pdf"
+        assert _normalize_pdf_url(url) == f"{BASE_URL}/Judgments/test.pdf"
+
+    def test_empty(self):
+        assert _normalize_pdf_url("") == ""
+
+    def test_whitespace(self):
+        assert _normalize_pdf_url("  ") == ""
+
+
+class TestParseLeadingJudgmentsRows:
+    @pytest.fixture
+    def sample_rows(self):
+        return [
+            {
+                "serial": "1",
+                "title": "Judgement on Chaddar or Parchi (Shariat Petition No. 10-I of 2023) dated 19.03.2025",
+                "pdf_url": "/Judgments/Shariat-Petition-No-10-I-of-2023.pdf",
+            },
+            {
+                "serial": "2",
+                "title": "Criminal Appeal No. 15-I of 2018 State vs Muhammad Akram dated 25.12.2024",
+                "pdf_url": "https://www.federalshariatcourt.gov.pk/Judgments/Cr.App.No.15.I.of.2018.pdf",
+            },
+            {
+                "serial": "3",
+                "title": "Jail Criminal Appeal No. 34-K of 1998 regarding Hudood Ordinance (01.06.2000)",
+                "pdf_url": "/Judgments/Jail%20Criminal%20Appeal%20No.%2034%20-%20K%20-%20of%201998.pdf",
+            },
+        ]
+
+    def test_parses_all_records(self, sample_rows):
+        records = parse_leading_judgments_rows(sample_rows, "test_source")
+        assert len(records) == 3
+        assert all(isinstance(r, JudgmentRecord) for r in records)
+
+    def test_case_number_extracted(self, sample_rows):
+        records = parse_leading_judgments_rows(sample_rows, "test_source")
+        assert "Shariat Petition" in records[0].case_number
+        assert "10-I" in records[0].case_number
+        assert "2023" in records[0].case_number
+
+    def test_case_type_classified(self, sample_rows):
+        records = parse_leading_judgments_rows(sample_rows, "test_source")
+        assert records[0].case_type == "Shariat Petition"
+        assert records[1].case_type == "Criminal Appeal"
+        assert records[2].case_type == "Jail Criminal Appeal"
+
+    def test_date_parsed(self, sample_rows):
+        records = parse_leading_judgments_rows(sample_rows, "test_source")
+        assert records[0].decision_date == "19.03.2025"
+        assert records[0].decision_date_parsed == date(2025, 3, 19)
+
+    def test_pdf_url_normalized(self, sample_rows):
+        records = parse_leading_judgments_rows(sample_rows, "test_source")
+        assert records[0].pdf_url.startswith("https://")
+        assert records[0].pdf_url.endswith(".pdf")
+        # Absolute URL should be kept as-is
+        assert records[1].pdf_url == (
+            "https://www.federalshariatcourt.gov.pk/Judgments/Cr.App.No.15.I.of.2018.pdf"
+        )
+
+    def test_source_url_set(self, sample_rows):
+        records = parse_leading_judgments_rows(sample_rows, "my_source")
+        assert all(r.source_url == "my_source" for r in records)
+
+    def test_empty_input(self):
+        records = parse_leading_judgments_rows([], "test")
+        assert records == []
+
+    def test_skips_empty_title(self):
+        rows = [{"serial": "1", "title": "", "pdf_url": "/test.pdf"}]
+        records = parse_leading_judgments_rows(rows, "test")
+        assert records == []
+
+    def test_parenthesized_date(self, sample_rows):
+        records = parse_leading_judgments_rows(sample_rows, "test")
+        # Record 3 has date in parentheses
+        assert records[2].decision_date == "01.06.2000"
+        assert records[2].decision_date_parsed == date(2000, 6, 1)
+
+
+class TestParseJudgmentSearchRows:
+    @pytest.fixture
+    def sample_rows(self):
+        return [
+            {
+                "serial": "1",
+                "case_number": "Shariat Petition No. 28-I of 1990",
+                "title": "Court Fees Act 1870",
+                "decision_date": "15.06.1992",
+                "pdf_url": "/Judgments/S.P.NO.28I.1990.pdf",
+            },
+            {
+                "serial": "2",
+                "case_number": "",
+                "title": "Criminal Revision No. 01-K of 2021 Sadam Hussain",
+                "decision_date": "10.03.2023",
+                "pdf_url": "/Judgments/Cr. Revision No.01-K of 2021.pdf",
+            },
+        ]
+
+    def test_parses_records(self, sample_rows):
+        records = parse_judgment_search_rows(sample_rows, "test")
+        assert len(records) == 2
+
+    def test_case_number_from_field(self, sample_rows):
+        records = parse_judgment_search_rows(sample_rows, "test")
+        assert records[0].case_number == "Shariat Petition No. 28-I of 1990"
+
+    def test_case_number_extracted_from_title(self, sample_rows):
+        records = parse_judgment_search_rows(sample_rows, "test")
+        # When case_number field is empty, extracted from title
+        assert "Criminal Revision" in records[1].case_number
+        assert "2021" in records[1].case_number
+
+    def test_pdf_url_normalized(self, sample_rows):
+        records = parse_judgment_search_rows(sample_rows, "test")
+        assert records[0].pdf_url.startswith("https://")
+
+    def test_date_parsed(self, sample_rows):
+        records = parse_judgment_search_rows(sample_rows, "test")
+        assert records[0].decision_date_parsed == date(1992, 6, 15)
+
+    def test_empty_list(self):
+        records = parse_judgment_search_rows([], "test")
+        assert records == []
+
+    def test_skips_empty_row(self):
+        rows = [{"serial": "1", "case_number": "", "title": ""}]
+        records = parse_judgment_search_rows(rows, "test")
+        assert records == []
+
+    def test_missing_fields(self):
+        rows = [{"serial": "1", "title": "Shariat Petition No. 5-I of 2020 some case"}]
+        records = parse_judgment_search_rows(rows, "test")
+        assert len(records) == 1
+        assert records[0].pdf_url == ""
+        assert records[0].decision_date == ""
+
+
+class TestCourtCode:
+    def test_court_code(self):
+        assert COURT_CODE == "FSC"


### PR DESCRIPTION
## Summary
- crawl4ai pipeline for FSC via federalshariatcourt.gov.pk
- Two crawl modes: leading judgments table + search form
- FSC-specific parsing: case type classification, multi-format dates
- Site currently unreachable (100% packet loss, confirms intermittent access)
- 52 offline tests

## Site Status
- federalshariatcourt.gov.pk completely unreachable
- WordPress-style /en/ URL structure discovered via Google cache
- Pipeline ready for when site comes back

## Test plan
- [x] 52 offline unit tests pass
- [ ] Live validation pending site restoration

Ref #7